### PR TITLE
Allow OAuth apps to use admin APIs

### DIFF
--- a/app/controllers/api/admin/application_controller.rb
+++ b/app/controllers/api/admin/application_controller.rb
@@ -33,6 +33,9 @@ module Api
         t = Doorkeeper::AccessToken.by_token(token)
         return false unless t&.acceptable?([ OauthApplication::ADMIN_SCOPE ])
 
+        application = t.application
+        return false unless application&.admin_scope? && application.confidential? && application.verified?
+
         u = User.find_by(id: t.resource_owner_id)
         return false unless admin_api_user?(u)
 

--- a/app/controllers/api/admin/application_controller.rb
+++ b/app/controllers/api/admin/application_controller.rb
@@ -4,6 +4,8 @@ module Api
       include ActionController::HttpAuthentication::Token::ControllerMethods
       include RenderHelpers
 
+      ADMIN_API_LEVELS = %w[admin superadmin viewer ultraadmin].freeze
+
       before_action :authenticate_admin!
       before_action :set_paper_trail_whodunnit
 
@@ -38,7 +40,7 @@ module Api
         true
       end
 
-      def admin_api_user?(u) = u&.admin_level.in?(%w[admin superadmin viewer ultraadmin])
+      def admin_api_user?(u) = u&.admin_level.in?(ADMIN_API_LEVELS)
       def current_user = @current_user
       def current_admin_api_key = @admin_api_key
       def current_oauth_token = @oauth_token

--- a/app/controllers/api/admin/application_controller.rb
+++ b/app/controllers/api/admin/application_controller.rb
@@ -4,42 +4,48 @@ module Api
       include ActionController::HttpAuthentication::Token::ControllerMethods
       include RenderHelpers
 
-      before_action :authenticate_admin_api_key!
+      before_action :authenticate_admin!
       before_action :set_paper_trail_whodunnit
 
       private
 
-      def authenticate_admin_api_key!
-        authenticate_or_request_with_http_token do |token, _options|
-          @admin_api_key = AdminApiKey.active.includes(:user).find_by(token: token)
-          next false unless @admin_api_key
-
-          @current_user = @admin_api_key.user
-          if @current_user.admin_level.in?(%w[admin superadmin viewer ultraadmin])
-            true
-          else
-            @admin_api_key.revoke!
-            false
-          end
+      def authenticate_admin!
+        authenticate_or_request_with_http_token do |token, _|
+          auth_admin_api_key(token) || auth_oauth_admin(token)
         end
       end
+      alias_method :authenticate_admin_api_key!, :authenticate_admin!
 
-      def current_user
-        @current_user
+      def auth_admin_api_key(token)
+        key = AdminApiKey.active.includes(:user).find_by(token: token) or return false
+        u = key.user
+        unless admin_api_user?(u)
+          key.revoke!
+          return false
+        end
+        @admin_api_key, @current_user = key, u
+        true
       end
 
-      def current_admin_api_key
-        @admin_api_key
+      def auth_oauth_admin(token)
+        t = Doorkeeper::AccessToken.by_token(token)
+        return false unless t&.acceptable?([ OauthApplication::ADMIN_SCOPE ])
+
+        u = User.find_by(id: t.resource_owner_id)
+        return false unless admin_api_user?(u)
+
+        @oauth_token, @current_user = t, u
+        true
       end
 
-      def set_paper_trail_whodunnit
-        PaperTrail.request.whodunnit = current_user&.id
-      end
+      def admin_api_user?(u) = u&.admin_level.in?(%w[admin superadmin viewer ultraadmin])
+      def current_user = @current_user
+      def current_admin_api_key = @admin_api_key
+      def current_oauth_token = @oauth_token
+      def set_paper_trail_whodunnit = PaperTrail.request.whodunnit = current_user&.id
 
       def require_superadmin
-        unless current_user&.admin_level_superadmin? || current_user&.admin_level_ultraadmin?
-          render_unauthorized("lmao no perms")
-        end
+        render_unauthorized("lmao no perms") unless current_user&.admin_level_superadmin? || current_user&.admin_level_ultraadmin?
       end
     end
   end

--- a/app/controllers/api/admin/v1/admin_controller.rb
+++ b/app/controllers/api/admin/v1/admin_controller.rb
@@ -8,7 +8,12 @@ module Api
           u = current_user
           body = {
             valid: true,
-            creator: { id: u.id, username: u.username, display_name: u.display_name, admin_level: u.admin_level }
+            creator: {
+              id: u.id,
+              username: u.username,
+              display_name: u.display_name,
+              admin_level: u.admin_level
+            }
           }
 
           if (k = current_admin_api_key)

--- a/app/controllers/api/admin/v1/admin_controller.rb
+++ b/app/controllers/api/admin/v1/admin_controller.rb
@@ -5,18 +5,25 @@ module Api
         include Api::Admin::V1::UserUtilities
 
         def check
-          api_key = current_admin_api_key
-          creator = User.find(api_key.user_id)
-          render json: {
+          u = current_user
+          body = {
             valid: true,
-            api_key: { id: api_key.id, name: api_key.name, created_at: api_key.created_at },
-            creator: {
-              id: creator.id,
-              username: creator.username,
-              display_name: creator.display_name,
-              admin_level: creator.admin_level
-            }
+            creator: { id: u.id, username: u.username, display_name: u.display_name, admin_level: u.admin_level }
           }
+
+          if (k = current_admin_api_key)
+            body[:auth] = { type: "api_key" }
+            body[:api_key] = { id: k.id, name: k.name, created_at: k.created_at }
+          elsif (t = current_oauth_token)
+            a = t.application
+            body[:auth] = {
+              type: "oauth",
+              application: { id: a&.id, name: a&.name, uid: a&.uid },
+              scopes: t.scopes.to_a
+            }
+          end
+
+          render json: body
         end
 
         def visualization_quantized

--- a/app/controllers/custom_doorkeeper/authorizations_controller.rb
+++ b/app/controllers/custom_doorkeeper/authorizations_controller.rb
@@ -4,6 +4,8 @@ module CustomDoorkeeper
   class AuthorizationsController < Doorkeeper::AuthorizationsController
     layout "inertia"
 
+    before_action :ensure_admin_scope_allowed!, only: %i[new create]
+
     def new
       if pre_auth.authorizable?
         if skip_authorization? || matching_token?
@@ -25,31 +27,42 @@ module CustomDoorkeeper
 
     private
 
+    def ensure_admin_scope_allowed!
+      return unless pre_auth&.scopes&.include?(OauthApplication::ADMIN_SCOPE)
+      return if current_resource_owner&.admin_level.in?(Api::Admin::ApplicationController::ADMIN_API_LEVELS)
+
+      render_oauth_error(
+        "Only admins can authorize applications that request the admin scope.",
+        status: :forbidden
+      )
+    end
+
     def render_error
       pre_auth.error_response.raise_exception! if Doorkeeper.config.raise_on_errors?
 
       if Doorkeeper.configuration.redirect_on_errors? && pre_auth.error_response.redirectable?
         redirect_or_render(pre_auth.error_response)
       else
-        render inertia: "OAuthAuthorize/Error", props: {
-          page_title: I18n.t("doorkeeper.authorizations.error.title"),
-          error_description: pre_auth.error_response.body[:error_description]
-        }
+        render_oauth_error(pre_auth.error_response.body[:error_description])
       end
     end
 
-    def authorize_props
-      app = pre_auth.client.application
+    def render_oauth_error(desc, status: :ok)
+      render inertia: "OAuthAuthorize/Error", props: {
+        page_title: I18n.t("doorkeeper.authorizations.error.title"),
+        error_description: desc
+      }, status: status
+    end
 
+    def authorize_props
+      a = pre_auth.client.application
       {
         page_title: I18n.t("doorkeeper.authorizations.new.title"),
         client_name: pre_auth.client.name,
-        verified: app.verified?,
-        scopes: pre_auth.scopes.map { |scope|
-          {
-            name: scope.to_s,
-            description: I18n.t(scope, scope: %i[doorkeeper scopes], default: scope.to_s.humanize)
-          }
+        verified: a.verified?,
+        has_admin_scope: pre_auth.scopes.include?(OauthApplication::ADMIN_SCOPE),
+        scopes: pre_auth.scopes.map { |s|
+          { name: s.to_s, description: I18n.t(s, scope: %i[doorkeeper scopes], default: s.to_s.humanize) }
         },
         form_data: {
           csrf_token: form_authenticity_token,
@@ -67,11 +80,7 @@ module CustomDoorkeeper
 
     def matching_token?
       Doorkeeper.config.reuse_access_token &&
-        Doorkeeper::AccessToken.matching_token_for(
-          pre_auth.client,
-          current_resource_owner,
-          pre_auth.scopes
-        ).present?
+        Doorkeeper::AccessToken.matching_token_for(pre_auth.client, current_resource_owner, pre_auth.scopes).present?
     end
   end
 end

--- a/app/controllers/custom_doorkeeper/authorizations_controller.rb
+++ b/app/controllers/custom_doorkeeper/authorizations_controller.rb
@@ -29,9 +29,25 @@ module CustomDoorkeeper
 
     def ensure_admin_scope_allowed!
       return unless pre_auth&.scopes&.include?(OauthApplication::ADMIN_SCOPE)
+      return unless pre_auth.authorizable?
 
-      application = OauthApplication.find_by(uid: params[:client_id])
-      return unless application
+      application = pre_auth.client.application
+
+      unless application.admin_scope?
+        render_oauth_error(
+          "Only applications configured with the admin scope can request it.",
+          status: :forbidden
+        )
+        return
+      end
+
+      unless application.confidential?
+        render_oauth_error(
+          "Only confidential applications can request the admin scope.",
+          status: :forbidden
+        )
+        return
+      end
 
       unless application.verified?
         render_oauth_error(

--- a/app/controllers/custom_doorkeeper/authorizations_controller.rb
+++ b/app/controllers/custom_doorkeeper/authorizations_controller.rb
@@ -29,6 +29,18 @@ module CustomDoorkeeper
 
     def ensure_admin_scope_allowed!
       return unless pre_auth&.scopes&.include?(OauthApplication::ADMIN_SCOPE)
+
+      application = OauthApplication.find_by(uid: params[:client_id])
+      return unless application
+
+      unless application.verified?
+        render_oauth_error(
+          "Only verified applications can request the admin scope.",
+          status: :forbidden
+        )
+        return
+      end
+
       return if current_resource_owner&.admin_level.in?(Api::Admin::ApplicationController::ADMIN_API_LEVELS)
 
       render_oauth_error(

--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -120,9 +120,20 @@ module Doorkeeper
     def application_params
       permitted = params.require(:doorkeeper_application)
         .permit(:name, :redirect_uri, :confidential, :redirect_to_hca_login, scopes: [])
-      permitted[:scopes] = permitted[:scopes].compact_blank.join(" ")
+      permitted[:scopes] = normalize_scopes(permitted[:scopes]).join(" ")
       permitted
     end
+
+    def normalize_scopes(raw)
+      scopes = Array(raw).compact_blank.map(&:to_s)
+      return scopes if can_assign_admin_scope?
+
+      scopes.delete(OauthApplication::ADMIN_SCOPE)
+      scopes |= [ OauthApplication::ADMIN_SCOPE ] if action_name == "update" && @application&.admin_scope?
+      scopes
+    end
+
+    def can_assign_admin_scope? = current_user&.admin_level.in?(AuthHelpers::ADMIN_LEVELS)
 
     def i18n_scope(action) = %i[doorkeeper flash applications] << action
 
@@ -217,6 +228,8 @@ module Doorkeeper
     def all_scope_options
       default_scopes = Doorkeeper.configuration.default_scopes.to_a.map(&:to_s)
       optional_scopes = Doorkeeper.configuration.optional_scopes.to_a.map(&:to_s)
+      optional_scopes -= [ OauthApplication::ADMIN_SCOPE ] unless can_assign_admin_scope?
+
       (default_scopes + optional_scopes).uniq.map { |scope|
         { value: scope,
           description: I18n.t(scope, scope: %i[doorkeeper scopes], default: scope.humanize),

--- a/app/javascript/pages/OAuthAuthorize/New.svelte
+++ b/app/javascript/pages/OAuthAuthorize/New.svelte
@@ -87,7 +87,11 @@
       <div
         class="mb-5 flex items-start gap-3 rounded-xl border-2 border-red bg-red/15 p-4"
       >
-        <svg class="mt-0.5 h-6 w-6 shrink-0 text-red" fill="currentColor" viewBox="0 0 20 20">
+        <svg
+          class="mt-0.5 h-6 w-6 shrink-0 text-red"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+        >
           <path fill-rule="evenodd" d={warnPath} clip-rule="evenodd" />
         </svg>
         <div>
@@ -111,7 +115,11 @@
       <div
         class="mb-5 flex items-start gap-3 rounded-xl border border-yellow/30 bg-yellow/10 p-4"
       >
-        <svg class="mt-0.5 h-5 w-5 shrink-0 text-yellow" fill="currentColor" viewBox="0 0 20 20">
+        <svg
+          class="mt-0.5 h-5 w-5 shrink-0 text-yellow"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+        >
           <path fill-rule="evenodd" d={warnPath} clip-rule="evenodd" />
         </svg>
         <div>

--- a/app/javascript/pages/OAuthAuthorize/New.svelte
+++ b/app/javascript/pages/OAuthAuthorize/New.svelte
@@ -27,12 +27,14 @@
     page_title,
     client_name,
     verified,
+    has_admin_scope = false,
     scopes,
     form_data,
   }: {
     page_title: string;
     client_name: string;
     verified: boolean;
+    has_admin_scope?: boolean;
     scopes: Scope[];
     form_data: FormData;
   } = $props();
@@ -42,10 +44,14 @@
   let authorizing = $state(false);
   let denying = $state(false);
 
+  const warnPath =
+    "M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z";
   const scopeIcons: Record<string, string> = {
     profile:
       "M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z",
     read: "M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z M15 12a3 3 0 11-6 0 3 3 0 016 0z",
+    admin:
+      "M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z",
   };
 
   const hiddenFields = $derived<[string, string][]>([
@@ -77,20 +83,36 @@
       </p>
     </div>
 
+    {#if has_admin_scope}
+      <div
+        class="mb-5 flex items-start gap-3 rounded-xl border-2 border-red bg-red/15 p-4"
+      >
+        <svg class="mt-0.5 h-6 w-6 shrink-0 text-red" fill="currentColor" viewBox="0 0 20 20">
+          <path fill-rule="evenodd" d={warnPath} clip-rule="evenodd" />
+        </svg>
+        <div>
+          <p class="text-base font-bold uppercase tracking-wide text-red">
+            Danger: Admin API access
+          </p>
+          <p class="mt-1 text-sm font-semibold text-red">
+            This app is requesting full Admin API access on your behalf. It can
+            read and act with your admin privileges (users, trust levels,
+            heartbeats, and other internal tools).
+          </p>
+          <p class="mt-1 text-sm text-red/90">
+            Only authorize if you recognize this internal tool and trust the
+            operators. If you did not expect this prompt, click Deny.
+          </p>
+        </div>
+      </div>
+    {/if}
+
     {#if !verified}
       <div
         class="mb-5 flex items-start gap-3 rounded-xl border border-yellow/30 bg-yellow/10 p-4"
       >
-        <svg
-          class="mt-0.5 h-5 w-5 shrink-0 text-yellow"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
-            clip-rule="evenodd"
-          />
+        <svg class="mt-0.5 h-5 w-5 shrink-0 text-yellow" fill="currentColor" viewBox="0 0 20 20">
+          <path fill-rule="evenodd" d={warnPath} clip-rule="evenodd" />
         </svg>
         <div>
           <p class="text-sm font-medium text-yellow">Unverified application</p>

--- a/app/javascript/pages/OAuthAuthorize/New.svelte
+++ b/app/javascript/pages/OAuthAuthorize/New.svelte
@@ -95,17 +95,13 @@
           <path fill-rule="evenodd" d={warnPath} clip-rule="evenodd" />
         </svg>
         <div>
-          <p class="text-base font-bold uppercase tracking-wide text-red">
-            Danger: Admin API access
+          <p class="text-base font-bold tracking-tight text-red">
+            You're giving access to admin data
           </p>
           <p class="mt-1 text-sm font-semibold text-red">
             This app is requesting full Admin API access on your behalf. It can
             read and act with your admin privileges (users, trust levels,
             heartbeats, and other internal tools).
-          </p>
-          <p class="mt-1 text-sm text-red/90">
-            Only authorize if you recognize this internal tool and trust the
-            operators. If you did not expect this prompt, click Deny.
           </p>
         </div>
       </div>

--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -1,4 +1,6 @@
 class OauthApplication < Doorkeeper::Application
+  ADMIN_SCOPE = "admin"
+
   belongs_to :owner, polymorphic: true, optional: true
 
   scope :verified, -> { where(verified: true) }
@@ -11,7 +13,7 @@ class OauthApplication < Doorkeeper::Application
   def admin_update(attrs) = with_admin_override { update(attrs) }
   def admin_update!(attrs) = with_admin_override { update!(attrs) }
 
-  def admin_scope? = scopes.to_a.include?("admin")
+  def admin_scope? = scopes.to_a.include?(ADMIN_SCOPE)
 
   private
 

--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -5,10 +5,13 @@ class OauthApplication < Doorkeeper::Application
   scope :unverified, -> { where(verified: false) }
 
   validate :locked_name, on: :update
+  validate :admin_scope_requires_confidential
 
   # Update as admin, bypassing the locked-name validation on verified apps.
   def admin_update(attrs) = with_admin_override { update(attrs) }
   def admin_update!(attrs) = with_admin_override { update!(attrs) }
+
+  def admin_scope? = scopes.to_a.include?("admin")
 
   private
 
@@ -23,5 +26,9 @@ class OauthApplication < Doorkeeper::Application
     return if @admin_override
     return unless verified? && name_changed?
     errors.add(:name, "cannot be changed for verified apps")
+  end
+
+  def admin_scope_requires_confidential
+    errors.add(:scopes, "admin scope requires a confidential application") if admin_scope? && !confidential?
   end
 end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -5,7 +5,7 @@ Doorkeeper.configure do
   application_class "OauthApplication"
 
   default_scopes "profile"
-  optional_scopes "read"
+  optional_scopes "read", "admin"
   enforce_configured_scopes
 
   resource_owner_authenticator do

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -159,3 +159,4 @@ en:
     scopes:
       profile: Access your basic profile info (user ID, emails, Slack ID, GitHub username)
       read: View your Hackatime stats, projects, heartbeats, and coding activity
+      admin: Access the Admin API on your behalf (user management, trust actions, heartbeats, and other internal tools)

--- a/docs/oauth/oauth-apps.md
+++ b/docs/oauth/oauth-apps.md
@@ -28,6 +28,7 @@ Scopes control what data your app can access. Request only the scopes you need.
 |-------|-------------|-------------------|
 | `profile` | Access basic profile information (user ID, email addresses, Slack ID, GitHub username, trust factor) | Yes |
 | `read` | View basic info about the user's Hackatime account | No |
+| `admin` | Access the [Admin API](#admin-api-access) on the authorizing admin's behalf | No |
 
 If you don't specify any scopes, only the `profile` scope is granted.
 
@@ -36,6 +37,12 @@ When requesting scopes in the authorization URL, separate multiple scopes with s
 ```
 scope=profile+read
 ```
+
+### Admin scope restrictions
+
+- Only **admin+** users (`admin`, `superadmin`, `ultraadmin`) can attach the `admin` scope to an OAuth application.
+- Apps with the `admin` scope must be **confidential** (server-side clients that can keep a secret).
+- Only staff can authorize an app that requests `admin`. Regular users are denied.
 
 ## Authorization Flow
 
@@ -120,6 +127,17 @@ Use the access token in the `Authorization` header:
 GET https://hackatime.hackclub.com/api/v1/authenticated/me
 Authorization: Bearer YOUR_ACCESS_TOKEN
 ```
+
+### Admin API access
+
+With a token that includes the `admin` scope, call Admin API endpoints the same way (instead of minting an Admin API key):
+
+```
+GET https://hackatime.hackclub.com/api/admin/v1/check
+Authorization: Bearer YOUR_ACCESS_TOKEN
+```
+
+The token acts as the authorizing staff member: permissions follow their `admin_level` (viewer is read-oriented; admin+ can write where the Admin API allows). Existing Admin API keys (`hka_…`) continue to work for scripts and CI.
 
 ## OAuth-Authenticated API Endpoints
 

--- a/spec/requests/api/admin/v1/admin_users_spec.rb
+++ b/spec/requests/api/admin/v1/admin_users_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Api::Admin::V1::AdminUsers', type: :request, openapi_spec: 'admi
   path '/api/admin/v1/check' do
     get('Check status') do
       tags 'Admin'
-      description 'Check if admin API is working. Returns metadata about the admin API key and its creator.'
+      description 'Check if admin API authentication is working. Returns metadata about the Admin API key or OAuth token and its authorizing user.'
       security [ AdminToken: [] ]
       produces 'application/json'
 
@@ -13,7 +13,7 @@ RSpec.describe 'Api::Admin::V1::AdminUsers', type: :request, openapi_spec: 'admi
         run_test!
       end
 
-      response(401, 'unauthorized — Returned when the bearer token is missing/invalid, or when the associated user is not an admin/superadmin/viewer/ultraadmin (the key is then revoked).') do
+      response(401, 'unauthorized — Returned when the bearer token is missing/invalid, the OAuth application is no longer eligible for admin access, or the associated user is not an admin/superadmin/viewer/ultraadmin. Demoted users have their Admin API key revoked.') do
         let(:Authorization) { "Bearer not-a-real-admin-token" }
         run_test!
       end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -333,7 +333,8 @@ RSpec.configure do |config|
         description: <<~DESC
           Admin and internal endpoints for Hackatime.
 
-          These require an Admin API Key (or internal env token) and are not part of the public API.
+          Admin endpoints require an Admin API Key or an OAuth access token with the `admin` scope.
+          Internal endpoints require an internal environment token. These endpoints are not part of the public API.
         DESC
       },
       paths: {},
@@ -342,7 +343,7 @@ RSpec.configure do |config|
           AdminToken: {
             type: :http,
             scheme: :bearer,
-            description: 'Admin API Key, prefixed with "Bearer"'
+            description: 'Admin API Key or OAuth access token with the `admin` scope, prefixed with "Bearer"'
           },
           InternalToken: {
             type: :http,

--- a/swagger/admin/swagger.yaml
+++ b/swagger/admin/swagger.yaml
@@ -6,7 +6,8 @@ info:
   description: |
     Admin and internal endpoints for Hackatime.
 
-    These require an Admin API Key (or internal env token) and are not part of the public API.
+    Admin endpoints require an Admin API Key or an OAuth access token with the `admin` scope.
+    Internal endpoints require an internal environment token. These endpoints are not part of the public API.
 paths:
   "/api/admin/v1/users/{id}/visualization/quantized":
     get:
@@ -2790,8 +2791,8 @@ paths:
       summary: Check status
       tags:
       - Admin
-      description: Check if admin API is working. Returns metadata about the admin
-        API key and its creator.
+      description: Check if admin API authentication is working. Returns metadata
+        about the Admin API key or OAuth token and its authorizing user.
       security:
       - AdminToken: []
       responses:
@@ -2799,8 +2800,9 @@ paths:
           description: successful
         '401':
           description: unauthorized — Returned when the bearer token is missing/invalid,
-            or when the associated user is not an admin/superadmin/viewer/ultraadmin
-            (the key is then revoked).
+            the OAuth application is no longer eligible for admin access, or the associated
+            user is not an admin/superadmin/viewer/ultraadmin. Demoted users have
+            their Admin API key revoked.
   "/api/admin/v1/banned_users":
     get:
       summary: Get banned users
@@ -3402,7 +3404,8 @@ components:
     AdminToken:
       type: http
       scheme: bearer
-      description: Admin API Key, prefixed with "Bearer"
+      description: Admin API Key or OAuth access token with the `admin` scope, prefixed
+        with "Bearer"
     InternalToken:
       type: http
       scheme: bearer

--- a/test/controllers/api/admin/v1/oauth_admin_auth_test.rb
+++ b/test/controllers/api/admin/v1/oauth_admin_auth_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::Admin::V1::OauthAdminAuthTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = User.create!(timezone: "UTC", admin_level: :admin, username: "oauth_admin_auth")
+    @oauth = @admin.oauth_applications.create!(
+      name: "Fraud Tool",
+      redirect_uri: "https://example.com/callback",
+      scopes: "profile admin",
+      confidential: true
+    )
+  end
+
+  test "accepts oauth admin token" do
+    get "/api/admin/v1/check", headers: bearer(oauth_token(@admin, "admin").token)
+    assert_response :success
+    b = response.parsed_body
+    assert_equal true, b["valid"]
+    assert_equal "oauth", b.dig("auth", "type")
+    assert_equal @oauth.uid, b.dig("auth", "application", "uid")
+    assert_includes b.dig("auth", "scopes"), "admin"
+    assert_equal @admin.id, b.dig("creator", "id")
+  end
+
+  test "rejects oauth token without admin scope" do
+    get "/api/admin/v1/check", headers: bearer(oauth_token(@admin, "profile").token)
+    assert_response :unauthorized
+  end
+
+  test "rejects oauth admin token after demotion" do
+    t = oauth_token(@admin, "admin")
+    @admin.update!(admin_level: :default)
+    get "/api/admin/v1/check", headers: bearer(t.token)
+    assert_response :unauthorized
+  end
+
+  test "still accepts admin api keys" do
+    key = @admin.admin_api_keys.create!(name: "legacy")
+    get "/api/admin/v1/check", headers: bearer(key.token)
+    assert_response :success
+    b = response.parsed_body
+    assert_equal "api_key", b.dig("auth", "type")
+    assert_equal key.id, b.dig("api_key", "id")
+  end
+
+  test "viewer oauth token can access admin check" do
+    v = User.create!(timezone: "UTC", admin_level: :viewer)
+    get "/api/admin/v1/check", headers: bearer(oauth_token(v, "admin").token)
+    assert_response :success
+    assert_equal "viewer", response.parsed_body.dig("creator", "admin_level")
+  end
+
+  private
+
+  def oauth_token(u, scopes)
+    Doorkeeper::AccessToken.create!(
+      application: @oauth, resource_owner_id: u.id, scopes: scopes, expires_in: 16.years
+    )
+  end
+
+  def bearer(t) = { "Authorization" => ActionController::HttpAuthentication::Token.encode_credentials(t) }
+end

--- a/test/controllers/api/admin/v1/oauth_admin_auth_test.rb
+++ b/test/controllers/api/admin/v1/oauth_admin_auth_test.rb
@@ -9,7 +9,8 @@ class Api::Admin::V1::OauthAdminAuthTest < ActionDispatch::IntegrationTest
       name: "Fraud Tool",
       redirect_uri: "https://example.com/callback",
       scopes: "profile admin",
-      confidential: true
+      confidential: true,
+      verified: true
     )
   end
 
@@ -32,6 +33,27 @@ class Api::Admin::V1::OauthAdminAuthTest < ActionDispatch::IntegrationTest
   test "rejects oauth admin token after demotion" do
     t = oauth_token(@admin, "admin")
     @admin.update!(admin_level: :default)
+    get "/api/admin/v1/check", headers: bearer(t.token)
+    assert_response :unauthorized
+  end
+
+  test "rejects oauth admin token after application is unverified" do
+    t = oauth_token(@admin, "admin")
+    @oauth.update!(verified: false)
+    get "/api/admin/v1/check", headers: bearer(t.token)
+    assert_response :unauthorized
+  end
+
+  test "rejects oauth admin token after admin scope is removed from application" do
+    t = oauth_token(@admin, "admin")
+    @oauth.update!(scopes: "profile")
+    get "/api/admin/v1/check", headers: bearer(t.token)
+    assert_response :unauthorized
+  end
+
+  test "rejects oauth admin token when application is no longer confidential" do
+    t = oauth_token(@admin, "admin")
+    @oauth.update_column(:confidential, false)
     get "/api/admin/v1/check", headers: bearer(t.token)
     assert_response :unauthorized
   end

--- a/test/controllers/custom_doorkeeper/authorizations_controller_test.rb
+++ b/test/controllers/custom_doorkeeper/authorizations_controller_test.rb
@@ -97,6 +97,24 @@ class CustomDoorkeeperAuthorizationsControllerTest < ActionDispatch::Integration
     assert_match(/admins/i, inertia_page.dig("props", "error_description"))
   end
 
+  test "new denies unverified applications requesting admin scope" do
+    enable_admin_scope!(verified: false)
+    sign_in_as(User.create!(timezone: "UTC", admin_level: :admin))
+    get "/oauth/authorize", params: authorization_params(scope: "admin")
+    assert_response :forbidden
+    assert_equal "OAuthAuthorize/Error", inertia_page["component"]
+    assert_match(/verified applications/i, inertia_page.dig("props", "error_description"))
+  end
+
+  test "create denies unverified applications requesting admin scope" do
+    enable_admin_scope!(verified: false)
+    sign_in_as(User.create!(timezone: "UTC", admin_level: :admin))
+    post "/oauth/authorize", params: authorization_params(scope: "admin")
+    assert_response :forbidden
+    assert_equal "OAuthAuthorize/Error", inertia_page["component"]
+    assert_match(/verified applications/i, inertia_page.dig("props", "error_description"))
+  end
+
   test "new allows viewer requesting admin scope with warning prop" do
     enable_admin_scope!
     sign_in_as(User.create!(timezone: "UTC", admin_level: :viewer))
@@ -116,8 +134,8 @@ class CustomDoorkeeperAuthorizationsControllerTest < ActionDispatch::Integration
 
   private
 
-  def enable_admin_scope!
-    @oauth_app.update!(scopes: "profile admin", confidential: true)
+  def enable_admin_scope!(verified: true)
+    @oauth_app.update!(scopes: "profile admin", confidential: true, verified: verified)
     Doorkeeper::AccessToken.where(application: @oauth_app).delete_all
   end
 

--- a/test/controllers/custom_doorkeeper/authorizations_controller_test.rb
+++ b/test/controllers/custom_doorkeeper/authorizations_controller_test.rb
@@ -88,14 +88,45 @@ class CustomDoorkeeperAuthorizationsControllerTest < ActionDispatch::Integration
     assert_equal "test_code", page.dig("props", "code")
   end
 
+  test "new denies non-admin users requesting admin scope" do
+    enable_admin_scope!
+    sign_in_as(@user)
+    get "/oauth/authorize", params: authorization_params(scope: "admin")
+    assert_response :forbidden
+    assert_equal "OAuthAuthorize/Error", inertia_page["component"]
+    assert_match(/admins/i, inertia_page.dig("props", "error_description"))
+  end
+
+  test "new allows viewer requesting admin scope with warning prop" do
+    enable_admin_scope!
+    sign_in_as(User.create!(timezone: "UTC", admin_level: :viewer))
+    get "/oauth/authorize", params: authorization_params(scope: "admin")
+    assert_response :success
+    assert_equal "OAuthAuthorize/New", inertia_page["component"]
+    assert_equal true, inertia_page.dig("props", "has_admin_scope")
+  end
+
+  test "new allows admin requesting admin scope" do
+    enable_admin_scope!
+    sign_in_as(User.create!(timezone: "UTC", admin_level: :admin))
+    get "/oauth/authorize", params: authorization_params(scope: "admin")
+    assert_response :success
+    assert_equal true, inertia_page.dig("props", "has_admin_scope")
+  end
+
   private
 
-  def authorization_params
+  def enable_admin_scope!
+    @oauth_app.update!(scopes: "profile admin", confidential: true)
+    Doorkeeper::AccessToken.where(application: @oauth_app).delete_all
+  end
+
+  def authorization_params(scope: "profile")
     {
       client_id: @oauth_app.uid,
       redirect_uri: "https://example.com/callback",
       response_type: "code",
-      scope: "profile"
+      scope: scope
     }
   end
 end

--- a/test/controllers/custom_doorkeeper/authorizations_controller_test.rb
+++ b/test/controllers/custom_doorkeeper/authorizations_controller_test.rb
@@ -115,6 +115,25 @@ class CustomDoorkeeperAuthorizationsControllerTest < ActionDispatch::Integration
     assert_match(/verified applications/i, inertia_page.dig("props", "error_description"))
   end
 
+  test "new denies applications without an explicitly configured admin scope" do
+    @oauth_app.update!(scopes: "", verified: true)
+    sign_in_as(User.create!(timezone: "UTC", admin_level: :admin))
+    get "/oauth/authorize", params: authorization_params(scope: "admin")
+    assert_response :forbidden
+    assert_equal "OAuthAuthorize/Error", inertia_page["component"]
+    assert_match(/configured with the admin scope/i, inertia_page.dig("props", "error_description"))
+  end
+
+  test "new denies public applications requesting admin scope" do
+    enable_admin_scope!
+    @oauth_app.update_column(:confidential, false)
+    sign_in_as(User.create!(timezone: "UTC", admin_level: :admin))
+    get "/oauth/authorize", params: authorization_params(scope: "admin")
+    assert_response :forbidden
+    assert_equal "OAuthAuthorize/Error", inertia_page["component"]
+    assert_match(/confidential applications/i, inertia_page.dig("props", "error_description"))
+  end
+
   test "new allows viewer requesting admin scope with warning prop" do
     enable_admin_scope!
     sign_in_as(User.create!(timezone: "UTC", admin_level: :viewer))
@@ -130,6 +149,13 @@ class CustomDoorkeeperAuthorizationsControllerTest < ActionDispatch::Integration
     get "/oauth/authorize", params: authorization_params(scope: "admin")
     assert_response :success
     assert_equal true, inertia_page.dig("props", "has_admin_scope")
+  end
+
+  test "create allows admin to authorize a verified confidential application with admin scope" do
+    enable_admin_scope!
+    sign_in_as(User.create!(timezone: "UTC", admin_level: :admin))
+    post "/oauth/authorize", params: authorization_params(scope: "admin")
+    assert_redirected_to %r{https://example\.com/callback\?code=}
   end
 
   private

--- a/test/controllers/doorkeeper/applications_controller_test.rb
+++ b/test/controllers/doorkeeper/applications_controller_test.rb
@@ -236,6 +236,51 @@ class Doorkeeper::ApplicationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal application.name, body["name"]
   end
 
+  test "new form omits admin scope for non-admin users" do
+    sign_in_as(User.create!(timezone: "UTC"))
+    get new_oauth_application_path
+    vals = scope_option_values
+    assert_includes vals, "profile"
+    assert_includes vals, "read"
+    assert_not_includes vals, "admin"
+  end
+
+  test "new form includes admin scope for admin users" do
+    sign_in_as(User.create!(timezone: "UTC", admin_level: :admin))
+    get new_oauth_application_path
+    assert_includes scope_option_values, "admin"
+  end
+
+  test "non-admin cannot create application with admin scope" do
+    sign_in_as(User.create!(timezone: "UTC"))
+    post oauth_applications_path, params: {
+      doorkeeper_application: valid_application_form_params(name: "Sneaky").merge(scopes: %w[profile admin])
+    }
+    app = OauthApplication.order(:created_at).last
+    assert_equal "Sneaky", app.name
+    assert_not_includes app.scopes.to_a, "admin"
+  end
+
+  test "admin can create confidential application with admin scope" do
+    sign_in_as(User.create!(timezone: "UTC", admin_level: :admin))
+    post oauth_applications_path, params: {
+      doorkeeper_application: valid_application_form_params(name: "Fraud Tool").merge(scopes: %w[profile admin])
+    }
+    assert_includes OauthApplication.order(:created_at).last.scopes.to_a, "admin"
+  end
+
+  test "admin scope requires confidential application" do
+    sign_in_as(User.create!(timezone: "UTC", admin_level: :admin))
+    assert_no_difference -> { OauthApplication.count } do
+      post oauth_applications_path, params: {
+        doorkeeper_application: valid_application_form_params(name: "Public Admin").merge(
+          scopes: %w[profile admin], confidential: "0"
+        )
+      }
+    end
+    assert_response :unprocessable_entity
+  end
+
   private
 
   def valid_application_params(name:)
@@ -257,5 +302,9 @@ class Doorkeeper::ApplicationsControllerTest < ActionDispatch::IntegrationTest
 
   def configured_scopes
     Doorkeeper.configuration.default_scopes.to_a.join(" ")
+  end
+
+  def scope_option_values
+    inertia_page.dig("props", "scope_options").map { |s| s["value"] }
   end
 end

--- a/test/services/dashboard_stats_test.rb
+++ b/test/services/dashboard_stats_test.rb
@@ -360,8 +360,9 @@ class DashboardStatsTest < ActiveSupport::TestCase
     with_memory_cache_store do
       Rails.cache.clear
 
-      user = User.create!(timezone: "UTC")
+      # Freeze time for the whole test so weekly rollups use the same week as the heartbeats.
       travel_to Time.utc(2026, 4, 14, 12, 0, 0) do
+        user = User.create!(timezone: "UTC")
         [ "<<LAST_PROJECT>>", "", nil, "Unknown" ].each_with_index do |project, index|
           start_at = Time.zone.parse("2026-04-13 09:00:00") + index.hours
           create_heartbeat_at(user, start_at.to_s, project:, language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
@@ -370,15 +371,15 @@ class DashboardStatsTest < ActiveSupport::TestCase
 
         create_heartbeat_at(user, "2026-04-13 14:00:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
         create_heartbeat_at(user, "2026-04-13 14:01:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+
+        DashboardRollupRefreshService.new(user: user).call
+        result = build_stats(user).filterable_dashboard_data
+
+        assert_equal "alpha", result["top_project"]
+        assert_equal [ "alpha" ], result[:project]
+        assert_equal({ "alpha" => 60 }, result[:project_durations])
+        assert_equal({ "alpha" => 60 }, result[:weekly_project_stats].fetch("2026-04-13"))
       end
-
-      DashboardRollupRefreshService.new(user: user).call
-      result = build_stats(user).filterable_dashboard_data
-
-      assert_equal "alpha", result["top_project"]
-      assert_equal [ "alpha" ], result[:project]
-      assert_equal({ "alpha" => 60 }, result[:project_durations])
-      assert_equal({ "alpha" => 60 }, result[:weekly_project_stats].fetch("2026-04-13"))
     end
   end
 


### PR DESCRIPTION
## Summary of the problem

The Hackatime API is great, but juggling API keys is cringe, and frankly, I am on the 7th API key that I lost, so it's time to change that.

## Describe your changes

- Added an OAuth admin scope so internal tools can “Sign in with Hackatime” and call the Admin API with a token instead of minting Admin API keys
  - This requires the app to be verified!
- Only admin+ can attach the scope to an app; viewer+ can authorize it (with a big scary consent warning)
- Admin API accepts either existing hka_ keys or OAuth tokens with the admin scope

## Screenshots / Media

Scary notice when authing apps that request the admin scope

<img width="1418" height="724" alt="image" src="https://github.com/user-attachments/assets/fd1a11e3-ff23-4bf7-8f25-ffe659634a9b" />
