### PR TITLE
Fix formatting in dashboard stats test so it passes

### DIFF
--- a/test/services/dashboard_stats_test.rb
+++ b/test/services/dashboard_stats_test.rb
@@ -370,15 +370,15 @@ class DashboardStatsTest < ActiveSupport::TestCase
 
         create_heartbeat_at(user, "2026-04-13 14:00:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
         create_heartbeat_at(user, "2026-04-13 14:01:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+
+        DashboardRollupRefreshService.new(user: user).call
+        result = build_stats(user).filterable_dashboard_data
+
+        assert_equal "alpha", result["top_project"]
+        assert_equal [ "alpha" ], result[:project]
+        assert_equal({ "alpha" => 60 }, result[:project_durations])
+        assert_equal({ "alpha" => 60 }, result[:weekly_project_stats].fetch("2026-04-13"))
       end
-
-      DashboardRollupRefreshService.new(user: user).call
-      result = build_stats(user).filterable_dashboard_data
-
-      assert_equal "alpha", result["top_project"]
-      assert_equal [ "alpha" ], result[:project]
-      assert_equal({ "alpha" => 60 }, result[:project_durations])
-      assert_equal({ "alpha" => 60 }, result[:weekly_project_stats].fetch("2026-04-13"))
     end
   end
 


### PR DESCRIPTION
## Summary of the problem

The test in `dashboard_stats_test.rb` was failing
this pr fixes it

## Describe your changes

Moves the `DashboardRollupRefreshService` call and assertions inside the `travel_to` block of the test.
This makes `week_ranges` compute relative to 2026-04-14 (where 2026-04-13 is within range) instead of the real current date where 2026-04-13 is now more than 12 weeks in the past.

## Screenshots / Media
<img width="751" height="341" alt="image" src="https://github.com/user-attachments/assets/5b691531-5725-47ae-9833-a1acc9cacd79" />
