### PR TITLE
Improve WakaTime heartbeat ingestion and AI metadata

### DIFF
--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -5,9 +5,10 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
   before_action :check_lockout, only: [ :push_heartbeats ]
 
   HEARTBEAT_KEYS = %i[
-    branch category created_at cursorpos dependencies editor entity is_write
-    language line_additions line_deletions lineno lines machine operating_system
-    project project_root_count time type user_agent plugin
+    ai_input_tokens ai_line_changes ai_model ai_output_tokens ai_prompt_length ai_session
+    ai_subscription_plan branch category created_at cursorpos editor
+    entity human_line_changes is_write language line_additions line_deletions lineno
+    lines machine operating_system project project_root_count time type user_agent plugin
   ].freeze
 
   MAX_BULK_HEARTBEATS = 100
@@ -15,7 +16,7 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
   def push_heartbeats
     if params["format"] == "bulk"
       # POST /api/hackatime/v1/users/:id/heartbeats.bulk
-      heartbeat_array = heartbeat_bulk_params[:heartbeats]
+      heartbeat_array = heartbeat_bulk_params[:heartbeats] || []
       return render_bad_request("No data provided...") if heartbeat_array.empty?
       if heartbeat_array.size > MAX_BULK_HEARTBEATS
         return render_bad_request("Too many heartbeats in a single request (max #{MAX_BULK_HEARTBEATS})")
@@ -27,8 +28,8 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
       heartbeat_array = Array.wrap(heartbeat_params)
       return render_bad_request("No data provided...") if heartbeat_array.empty? || heartbeat_params.blank?
 
-      new_heartbeat = handle_heartbeat(heartbeat_array)&.first&.first
-      render json: new_heartbeat, status: :accepted
+      response_body, response_status = handle_heartbeat(heartbeat_array).first
+      render json: response_body, status: response_status == 201 ? :accepted : response_status
     end
   end
 
@@ -161,6 +162,7 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
       request_context: {
         ip_address: request.headers["CF-Connecting-IP"] || request.remote_ip,
         machine: request.headers["X-Machine-Name"],
+        user_agent: request.user_agent,
         ja4: request.headers["CF-JA4"]
       }
     )
@@ -202,26 +204,49 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
   # allow either heartbeat or heartbeats
   def heartbeat_bulk_params
     if params[:_json].present?
-      { heartbeats: params.permit(_json: [ *HEARTBEAT_KEYS ])[:_json] }
+      { heartbeats: permit_heartbeat_collection(params[:_json]) }
     elsif request.content_type&.include?("text/plain") && request.raw_post.present?
-      parsed_json = JSON.parse(request.raw_post, symbolize_names: true) rescue []
-      { heartbeats: parsed_json.map { |hb| hb.slice(*HEARTBEAT_KEYS) } }
+      { heartbeats: permit_heartbeat_collection(parse_plain_json) }
     else
-      params.require(:hackatime).permit(heartbeats: [ *HEARTBEAT_KEYS ])
+      hackatime = params.require(:hackatime)
+      { heartbeats: permit_heartbeat_collection(hackatime[:heartbeats]) }
     end
   end
 
   def heartbeat_params
     if params[:_json].present?
-      params[:_json].first.permit(*HEARTBEAT_KEYS)
+      permit_heartbeat(params[:_json].first) || {}
     elsif request.content_type&.include?("text/plain") && request.raw_post.present?
-      parsed = JSON.parse(request.raw_post, symbolize_names: true) rescue {}
+      parsed = parse_plain_json
       parsed = [ parsed ] unless parsed.is_a?(Array)
-      parsed.first&.with_indifferent_access&.slice(*HEARTBEAT_KEYS) || {}
+      permit_heartbeat(parsed.first) || {}
     elsif params[:hackatime].present?
-      params.require(:hackatime).permit(*HEARTBEAT_KEYS)
+      permit_heartbeat(params.require(:hackatime)) || {}
     else
-      params.permit(*HEARTBEAT_KEYS)
+      permit_heartbeat(params) || {}
+    end
+  end
+
+  def parse_plain_json
+    JSON.parse(request.raw_post)
+  rescue JSON::ParserError
+    nil
+  end
+
+  def permit_heartbeat_collection(value)
+    return [] unless value.is_a?(Array)
+
+    # Preserve array positions so a malformed item receives its own response
+    # instead of discarding every valid heartbeat in the same CLI bulk upload.
+    value.map { |heartbeat| permit_heartbeat(heartbeat) }
+  end
+
+  def permit_heartbeat(value)
+    case value
+    when ActionController::Parameters
+      value.permit(*HEARTBEAT_KEYS, dependencies: [])
+    when Hash
+      ActionController::Parameters.new(value).permit(*HEARTBEAT_KEYS, dependencies: [])
     end
   end
 end

--- a/app/controllers/my/project_repo_mappings_controller.rb
+++ b/app/controllers/my/project_repo_mappings_controller.rb
@@ -150,6 +150,7 @@ class My::ProjectRepoMappingsController < InertiaController
 
   def projects_data_for_index(archived:)
     return empty_projects_payload unless current_user.heartbeats.exists?
+    return InertiaRails.defer { projects_payload(archived:) } if archived
     return rollup_projects_payload(archived: archived) if rollup_projects_path?
 
     InertiaRails.defer { projects_payload(archived: archived) }

--- a/app/jobs/heartbeat_export_job.rb
+++ b/app/jobs/heartbeat_export_job.rb
@@ -11,9 +11,10 @@ class HeartbeatExportJob < ApplicationJob
   )
 
   HEARTBEAT_EXPORT_FIELDS = %i[
-    id entity type category project language editor operating_system machine
-    branch user_agent is_write line_additions line_deletions lineno lines
-    cursorpos dependencies source_type
+    id entity type category project language editor operating_system machine branch
+    user_agent is_write line_additions line_deletions lineno lines cursorpos dependencies
+    source_type ai_model ai_session ai_subscription_plan ai_input_tokens ai_output_tokens
+    ai_prompt_length ai_line_changes human_line_changes
   ].freeze
 
   def perform(user_id, all_data:, start_date: nil, end_date: nil)

--- a/app/models/heartbeat.rb
+++ b/app/models/heartbeat.rb
@@ -38,11 +38,20 @@ class Heartbeat < ApplicationRecord
   def self.recent_imported_count = Cache::HeartbeatCountsJob.perform_now[:recent_imported_count]
 
   def self.generate_fields_hash(attributes)
-    Digest::MD5.hexdigest(attributes.transform_keys(&:to_s).slice(*self.indexed_attributes).to_json)
+    attributes = attributes.transform_keys(&:to_s)
+    indexed = attributes.slice(*indexed_attributes)
+    ai_indexed_attributes.each do |attribute|
+      indexed[attribute] = attributes[attribute] unless attributes[attribute].nil?
+    end
+    Digest::MD5.hexdigest(indexed.to_json)
   end
 
   def self.indexed_attributes
     %w[user_id branch category dependencies editor entity language machine operating_system project type user_agent line_additions line_deletions lineno lines cursorpos project_root_count time is_write]
+  end
+
+  def self.ai_indexed_attributes
+    %w[ai_model ai_session ai_subscription_plan ai_input_tokens ai_output_tokens ai_prompt_length ai_line_changes human_line_changes]
   end
 
   def soft_delete

--- a/app/models/project_repo_mapping.rb
+++ b/app/models/project_repo_mapping.rb
@@ -1,5 +1,5 @@
 class ProjectRepoMapping < ApplicationRecord
-  IGNORED_PROJECTS = [ nil, "", "<<LAST PROJECT>>" ]
+  IGNORED_PROJECTS = [ nil, "", "<<LAST_PROJECT>>" ].freeze
 
   belongs_to :user
   belongs_to :repository, optional: true

--- a/app/services/heartbeat_import_service.rb
+++ b/app/services/heartbeat_import_service.rb
@@ -6,11 +6,11 @@ class HeartbeatImportService
     total_count = 0
     errors = []
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    heartbeat_batch = {}
+    heartbeat_batch = []
 
     flush = lambda do
       next if heartbeat_batch.empty?
-      result = HeartbeatIngest.call(user:, mode: :import, heartbeats: heartbeat_batch.values,
+      result = HeartbeatIngest.call(user:, mode: :import, heartbeats: heartbeat_batch,
                                     user_agents_by_id:, schedule_rollup_refresh: false)
       imported_count += result.persisted_count
       errors.concat(result.errors)
@@ -21,13 +21,8 @@ class HeartbeatImportService
       total_count += 1
       on_progress&.call(total_count) if progress_interval.positive? && (total_count % progress_interval).zero?
 
-      begin
-        attrs = HeartbeatIngest.normalize_imported_heartbeat(user:, heartbeat: hb, user_agents_by_id:)
-        heartbeat_batch[attrs[:fields_hash]] = hb
-        flush.call if heartbeat_batch.size >= BATCH_SIZE
-      rescue => e
-        errors << { heartbeat: hb, error: e.message }
-      end
+      heartbeat_batch << hb
+      flush.call if heartbeat_batch.size >= BATCH_SIZE
     end
 
     Oj.saj_parse(handler, file_content)

--- a/app/services/heartbeat_ingest.rb
+++ b/app/services/heartbeat_ingest.rb
@@ -22,8 +22,6 @@ class HeartbeatIngest
   def self.call(...) = new(...).call
   def self.schedule_rollup_refresh(user:) = DashboardRollupRefreshJob.schedule_for(user.id)
 
-  def self.normalize_imported_heartbeat(user:, heartbeat:, user_agents_by_id: {}) = new(user:, mode: :import, heartbeats: [], user_agents_by_id:).send(:normalize_imported_heartbeat, heartbeat)
-
   def initialize(user:, mode:, heartbeats:, request_context: {}, user_agents_by_id: {}, schedule_rollup_refresh: true)
     @user = user
     @mode = mode

--- a/app/services/heartbeat_ingest.rb
+++ b/app/services/heartbeat_ingest.rb
@@ -261,21 +261,87 @@ class HeartbeatIngest
       .except("id", "fields_hash", "created_at", "updated_at", "time_epoch")
       .symbolize_keys
     normalized[:fields_hash] = Heartbeat.generate_fields_hash(model_attributes)
+    normalized[:legacy_fields_hash] = legacy_import_fields_hash(
+      hb,
+      user_agent_info:,
+      resolved_user_agent:,
+      normalized_time: normalized[:time]
+    )
     update_placeholder_state!(normalized, placeholder_state)
     normalized
   end
 
   def flush_import_batch(seen_hashes)
     return 0 if seen_hashes.empty?
+
+    records = seen_hashes.values
+    compatible_hashes = records.flat_map { |record| [ record[:fields_hash], record[:legacy_fields_hash] ] }.compact.uniq
+    existing_hashes = compatible_hashes.each_slice(10_000).flat_map do |hashes|
+      @user.heartbeats.where(fields_hash: hashes).pluck(:fields_hash)
+    end.to_set
+    records = records.reject do |record|
+      existing_hashes.include?(record[:fields_hash]) || existing_hashes.include?(record[:legacy_fields_hash])
+    end
+    return 0 if records.empty?
+
     timestamp = Time.current
     ActiveRecord::Base.logger.silence do
       # Build records inside the retry block so a cutover-time schema refresh
       # recomputes both the conflict target and the time_epoch partition column.
       with_heartbeat_unique_by do |unique_by|
-        records = seen_hashes.values.map { |r| r.merge(created_at: timestamp, updated_at: timestamp, **partition_attrs(r[:time])) }
-        Heartbeat.insert_all(records, unique_by:).length
+        insert_records = records.map do |record|
+          record.except(:legacy_fields_hash)
+            .merge(created_at: timestamp, updated_at: timestamp, **partition_attrs(record[:time]))
+        end
+        Heartbeat.insert_all(insert_records, unique_by:).length
       end
     end
+  end
+
+  # Import normalization is part of the persisted dedup contract. Keep the
+  # pre-parity hash as a lookup alias so re-importing an old dump cannot mint a
+  # second row merely because canonical category, project or UA values changed.
+  def legacy_import_fields_hash(hb, user_agent_info:, resolved_user_agent:, normalized_time:)
+    legacy_user_agent = legacy_parse_user_agent(resolved_user_agent)
+    Heartbeat.generate_fields_hash(
+      user_id: @user.id,
+      time: normalized_time,
+      entity: hb[:entity],
+      type: hb[:type],
+      category: hb[:category] || "coding",
+      project: hb[:project],
+      language: LanguageUtils.fill_missing_language(hb[:language], entity: hb[:entity]),
+      editor: hb[:editor].presence || user_agent_info[:editor].presence || legacy_user_agent[:editor].presence,
+      operating_system: hb[:operating_system].presence || user_agent_info[:os].presence || legacy_user_agent[:os].presence,
+      machine: hb[:machine].presence || hb[:machine_name_id].presence,
+      branch: hb[:branch],
+      user_agent: resolved_user_agent,
+      is_write: hb[:is_write] || false,
+      line_additions: hb[:line_additions],
+      line_deletions: hb[:line_deletions],
+      lineno: hb[:lineno],
+      lines: hb[:lines],
+      cursorpos: hb[:cursorpos],
+      dependencies: hb[:dependencies] || [],
+      project_root_count: hb[:project_root_count]
+    )
+  end
+
+  def legacy_parse_user_agent(user_agent)
+    return { editor: nil, os: nil } if user_agent.blank?
+
+    if matches = user_agent.match(/wakatime\/[^ ]+ \(([^)]+)\)(?: [^ ]+ ([^\/]+)(?:\/([^\/]+))?)?/)
+      return { os: matches[1].split("-").first, editor: matches[2].presence }
+    end
+
+    browser = user_agent.match(/^([^\/]+)\/([^\/\s]+)/)
+    return { editor: nil, os: nil } unless browser
+    return { editor: browser[2], os: browser[1] } unless user_agent.include?("wakatime")
+
+    full_os = user_agent.split(" ")[1]
+    return { editor: nil, os: nil } if full_os.blank?
+
+    { editor: browser[1].downcase, os: full_os.include?("_") ? full_os.split("_").first : full_os }
   end
 
   def heartbeat_unique_by

--- a/app/services/heartbeat_ingest.rb
+++ b/app/services/heartbeat_ingest.rb
@@ -138,8 +138,8 @@ class HeartbeatIngest
     inserted_by_hash = {}
     if missing_entries.any?
       timestamp = Time.current
-      records = missing_entries.map { |entry| direct_insert_record(entry, timestamp:) }
       result = with_heartbeat_unique_by do |unique_by|
+        records = missing_entries.map { |entry| direct_insert_record(entry, timestamp:) }
         Heartbeat.insert_all(records, unique_by:, returning: Heartbeat.column_names)
       end
       inserted_by_hash = result.to_a.index_by { |attributes| attributes.fetch("fields_hash") }

--- a/app/services/heartbeat_ingest.rb
+++ b/app/services/heartbeat_ingest.rb
@@ -113,7 +113,7 @@ class HeartbeatIngest
       attrs[:language] = inferred if inferred
     end
 
-    attrs[:category] = default_category(attrs[:category], type: attrs[:type], language: attrs[:language])
+    attrs[:category] = default_category(attrs[:category], type: attrs[:type])
     attrs[:user_agent] = attrs[:user_agent].presence || attrs.delete(:plugin).presence || @request_context[:user_agent].presence
     parsed_ua = WakatimeService.parse_user_agent(attrs[:user_agent], category: attrs[:category])
 
@@ -257,7 +257,7 @@ class HeartbeatIngest
     }
     resolve_placeholders!(attrs, placeholder_state)
     attrs[:language] = LanguageUtils.fill_missing_language(attrs[:language], entity: attrs[:entity])
-    attrs[:category] = default_category(attrs[:category], type: attrs[:type], language: attrs[:language])
+    attrs[:category] = default_category(attrs[:category], type: attrs[:type])
     model_attributes = validated_model_attributes(attrs)
     normalized = model_attributes
       .except("id", "fields_hash", "created_at", "updated_at", "time_epoch")
@@ -351,12 +351,11 @@ class HeartbeatIngest
     { editor: parsed[:editor].presence, os: parsed[:os].presence, ai_model: parsed[:ai_model].presence }
   end
 
-  def default_category(category, type:, language:)
+  def default_category(category, type:)
     return category if category.present?
     return "browsing" if %w[domain url].include?(type)
-    return "coding" if type == "file" && language.present?
 
-    nil
+    "coding"
   end
 
   # `<<LAST_PROJECT>>` stays persisted by design, but language and branch need

--- a/app/services/heartbeat_ingest.rb
+++ b/app/services/heartbeat_ingest.rb
@@ -260,7 +260,7 @@ class HeartbeatIngest
     normalized = model_attributes
       .except("id", "fields_hash", "created_at", "updated_at", "time_epoch")
       .symbolize_keys
-    normalized[:fields_hash] = Heartbeat.generate_fields_hash(model_attributes)
+    normalized[:fields_hash] = import_fields_hash(model_attributes, source: hb)
     normalized[:legacy_fields_hash] = legacy_import_fields_hash(
       hb,
       user_agent_info:,
@@ -325,6 +325,16 @@ class HeartbeatIngest
       dependencies: hb[:dependencies] || [],
       project_root_count: hb[:project_root_count]
     )
+  end
+
+  # Resolved placeholders are useful metadata, but database-backed resolution
+  # can change between identical imports. Keep the raw sentinel in the persisted
+  # identity so fields_hash remains a pure function of the dump row.
+  def import_fields_hash(model_attributes, source:)
+    hash_attributes = model_attributes.dup
+    hash_attributes["language"] = LAST_LANGUAGE_SENTINEL if source[:language] == LAST_LANGUAGE_SENTINEL
+    hash_attributes["branch"] = LAST_BRANCH_SENTINEL if source[:branch] == LAST_BRANCH_SENTINEL
+    Heartbeat.generate_fields_hash(hash_attributes)
   end
 
   def legacy_parse_user_agent(user_agent)

--- a/app/services/heartbeat_ingest.rb
+++ b/app/services/heartbeat_ingest.rb
@@ -1,5 +1,10 @@
 class HeartbeatIngest
+  class InvalidHeartbeatTime < ArgumentError; end
+
   LAST_LANGUAGE_SENTINEL = "<<LAST_LANGUAGE>>"
+  LAST_BRANCH_SENTINEL = "<<LAST_BRANCH>>"
+  LAST_PROJECT_SENTINEL = "<<LAST_PROJECT>>"
+  DIRECT_FUTURE_TOLERANCE = 1.hour
 
   # Sane epoch-seconds window: 2001-09-09 .. 2033-05-18. Values outside are
   # client bugs (uptime-like numbers, literal years, ms/µs/ns-scaled epochs).
@@ -39,20 +44,49 @@ class HeartbeatIngest
   private
 
   def ingest_direct
-    items, errors = [], []
+    items = Array.new(@heartbeats.length)
+    errors = []
+    entries = []
     persisted_count = duplicate_count = 0
-    last_language = nil
+    placeholder_state = { contexts: {}, last_project: nil }
 
-    @heartbeats.each do |heartbeat|
-      attrs = normalize_direct_heartbeat(heartbeat, last_language:)
-      persisted, duplicate = persist_direct_heartbeat(attrs)
-      last_language = attrs[:language] if attrs[:language].present?
-      duplicate ? duplicate_count += 1 : persisted_count += 1
-      items << Item.new(heartbeat: persisted, status: :accepted, error: nil)
-      queue_project_mapping(attrs[:project])
+    @heartbeats.each_with_index do |heartbeat, index|
+      attrs = normalize_direct_heartbeat(heartbeat, placeholder_state:)
+      model_attributes = validated_model_attributes(attrs)
+      attrs = model_attributes.symbolize_keys
+      update_placeholder_state!(attrs, placeholder_state)
+      entries << {
+        index:,
+        heartbeat:,
+        attrs:,
+        model_attributes:,
+        fields_hash: Heartbeat.generate_fields_hash(model_attributes)
+      }
     rescue => e
       errors << { heartbeat: heartbeat, error: e.message, type: e.class.name }
-      items << Item.new(heartbeat: nil, status: :failed, error: e)
+      items[index] = Item.new(heartbeat: nil, status: :failed, error: e)
+    end
+
+    if entries.any?
+      begin
+        persisted_by_hash, inserted_hashes = persist_direct_heartbeats(entries)
+        persisted_count = inserted_hashes.length
+        duplicate_count = entries.length - persisted_count
+
+        entries.each do |entry|
+          items[entry[:index]] = Item.new(
+            heartbeat: persisted_by_hash.fetch(entry[:fields_hash]),
+            status: :accepted,
+            error: nil
+          )
+        end
+        entries.map { |entry| entry[:attrs][:project] }.uniq.each { |project| queue_project_mapping(project) }
+      rescue => e
+        entries.each do |entry|
+          errors << { heartbeat: entry[:heartbeat], error: e.message, type: e.class.name }
+          items[entry[:index]] = Item.new(heartbeat: nil, status: :failed, error: e)
+        end
+      end
     end
 
     Result.new(
@@ -65,63 +99,105 @@ class HeartbeatIngest
     )
   end
 
-  def normalize_direct_heartbeat(heartbeat, last_language:)
+  def normalize_direct_heartbeat(heartbeat, placeholder_state:)
     attrs = heartbeat.to_h.with_indifferent_access
-    attrs[:time] = normalize_epoch_time(attrs[:time]) if attrs[:time].present?
+    attrs[:time] = normalize_heartbeat_time(attrs[:time])
+    validate_direct_time!(attrs[:time])
     source_type = attrs[:entity] == "test.txt" ? :test_entry : :direct_entry
+    attrs[:project] = sanitize_project(attrs[:project])
 
-    if attrs[:language] == LAST_LANGUAGE_SENTINEL
-      attrs[:language] = last_language || @user.heartbeats
-        .where.not(language: [ nil, "", LAST_LANGUAGE_SENTINEL ]).order(time: :desc).pick(:language)
-    end
+    resolve_placeholders!(attrs, placeholder_state)
 
     if attrs[:language].blank? || attrs[:language] == "Unknown"
       inferred = LanguageUtils.detect_from_extension(attrs[:entity])
       attrs[:language] = inferred if inferred
     end
 
-    attrs[:user_agent] ||= attrs.delete(:plugin)
-    parsed_ua = WakatimeService.parse_user_agent(attrs[:user_agent])
-    attrs[:category] ||= "coding"
-    attrs[:project] = attrs[:project]&.gsub(/[[:cntrl:]]/, "")&.strip
+    attrs[:category] = default_category(attrs[:category], type: attrs[:type], language: attrs[:language])
+    attrs[:user_agent] = attrs[:user_agent].presence || attrs.delete(:plugin).presence || @request_context[:user_agent].presence
+    parsed_ua = WakatimeService.parse_user_agent(attrs[:user_agent], category: attrs[:category])
 
     attrs.merge(
       user_id: @user.id,
       source_type:,
       ip_address: @request_context[:ip_address],
       ja4_id: resolved_ja4&.id,
-      editor: parsed_ua[:editor],
-      operating_system: parsed_ua[:os],
-      machine: @request_context[:machine]
+      ai_model: attrs[:ai_model].presence || parsed_ua[:ai_model],
+      editor: parsed_ua[:editor].presence || attrs[:editor].presence,
+      operating_system: parsed_ua[:os].presence || attrs[:operating_system].presence,
+      machine: @request_context[:machine].presence || attrs[:machine].presence
     ).slice(*Heartbeat.column_names.map(&:to_sym))
   end
 
-  def persist_direct_heartbeat(attrs)
-    fields_hash = Heartbeat.generate_fields_hash(Heartbeat.new(attrs).attributes)
-    existing = @user.heartbeats.find_by(fields_hash: fields_hash)
-    return [ existing, true ] if existing
-
-    now = Time.current
-    result = with_heartbeat_unique_by do |unique_by|
-      Heartbeat.insert(
-        attrs.merge(fields_hash:, created_at: now, updated_at: now, **partition_attrs(attrs[:time])),
-        unique_by:, returning: Heartbeat.column_names
-      )
+  def persist_direct_heartbeats(entries)
+    entries_by_hash = entries.group_by { |entry| entry[:fields_hash] }
+    hashes = entries_by_hash.keys
+    persisted_by_hash = @user.heartbeats.where(fields_hash: hashes).index_by(&:fields_hash)
+    missing_entries = entries_by_hash.filter_map do |fields_hash, matching_entries|
+      matching_entries.first unless persisted_by_hash.key?(fields_hash)
     end
 
-    persisted = result.any? ? Heartbeat.new(result.first) : @user.heartbeats.find_by!(fields_hash:)
-    self.class.schedule_rollup_refresh(user: @user) if result.any? && @schedule_rollup_refresh
-    [ persisted, !result.any? ]
+    inserted_by_hash = {}
+    if missing_entries.any?
+      timestamp = Time.current
+      records = missing_entries.map { |entry| direct_insert_record(entry, timestamp:) }
+      result = with_heartbeat_unique_by do |unique_by|
+        Heartbeat.insert_all(records, unique_by:, returning: Heartbeat.column_names)
+      end
+      inserted_by_hash = result.to_a.index_by { |attributes| attributes.fetch("fields_hash") }
+        .transform_values { |attributes| Heartbeat.new(attributes) }
+      persisted_by_hash.merge!(inserted_by_hash)
+
+      # Another request can win the conflict after our prefetch but before the
+      # insert. ON CONFLICT skips those rows, so fetch the winners once.
+      unresolved_hashes = missing_entries.map { |entry| entry[:fields_hash] } - inserted_by_hash.keys
+      if unresolved_hashes.any?
+        persisted_by_hash.merge!(
+          @user.heartbeats.where(fields_hash: unresolved_hashes).index_by(&:fields_hash)
+        )
+      end
+    end
+
+    hashes.each { |fields_hash| persisted_by_hash.fetch(fields_hash) }
+    if inserted_by_hash.any? && @schedule_rollup_refresh
+      self.class.schedule_rollup_refresh(user: @user)
+    end
+
+    [ persisted_by_hash, inserted_by_hash.keys ]
+  end
+
+  # insert_all deliberately skips the Active Record lifecycle. Run the normal
+  # validation chain against the type-cast model before constructing the bulk
+  # record. The user association avoids one existence query per heartbeat.
+  # Persistence callbacks remain explicit in the record-construction and
+  # batch-persistence methods so the actual insert stays multi-row.
+  def validated_model_attributes(attrs)
+    heartbeat = Heartbeat.new(attrs)
+    heartbeat.user = @user
+    heartbeat.validate!
+    heartbeat.attributes
+  end
+
+  def direct_insert_record(entry, timestamp:)
+    entry[:model_attributes]
+      .except("id", "fields_hash", "created_at", "updated_at", "time_epoch")
+      .merge(
+        "fields_hash" => entry[:fields_hash],
+        "created_at" => timestamp,
+        "updated_at" => timestamp,
+        **partition_attrs(entry[:attrs][:time]).stringify_keys
+      )
   end
 
   def ingest_import
     seen_hashes = {}
     total_count = 0
     errors = []
+    placeholder_state = { contexts: {}, last_project: nil }
 
     @heartbeats.each do |heartbeat|
       total_count += 1
-      attrs = normalize_imported_heartbeat(heartbeat)
+      attrs = normalize_imported_heartbeat(heartbeat, placeholder_state:)
       existing = seen_hashes[attrs[:fields_hash]]
       seen_hashes[attrs[:fields_hash]] = attrs if existing.nil? || attrs[:time] > existing[:time]
     rescue => e
@@ -141,21 +217,30 @@ class HeartbeatIngest
     )
   end
 
-  def normalize_imported_heartbeat(heartbeat)
+  def normalize_imported_heartbeat(heartbeat, placeholder_state: { contexts: {}, last_project: nil })
     hb = heartbeat.respond_to?(:with_indifferent_access) ? heartbeat.with_indifferent_access : heartbeat.to_h.with_indifferent_access
     user_agent_info = (@user_agents_by_id[hb[:user_agent_id].to_s] || {}).with_indifferent_access
     resolved_user_agent = hb[:user_agent].presence || user_agent_info[:value].presence || hb[:user_agent_id].presence
-    parsed_user_agent = parse_user_agent(resolved_user_agent)
+    parsed_user_agent = parse_user_agent(resolved_user_agent, category: hb[:category])
+    derived_ai_editor = parsed_user_agent[:editor].presence if parsed_user_agent[:ai_model].present?
 
     attrs = {
+      ai_model: hb[:ai_model].presence || parsed_user_agent[:ai_model].presence,
+      ai_session: hb[:ai_session],
+      ai_subscription_plan: hb[:ai_subscription_plan],
+      ai_input_tokens: hb[:ai_input_tokens],
+      ai_output_tokens: hb[:ai_output_tokens],
+      ai_prompt_length: hb[:ai_prompt_length],
+      ai_line_changes: hb[:ai_line_changes],
+      human_line_changes: hb[:human_line_changes],
       user_id: @user.id,
-      time: normalize_epoch_time(hb[:time].is_a?(String) ? Time.parse(hb[:time]).to_f : hb[:time]),
+      time: normalize_heartbeat_time(hb[:time]),
       entity: hb[:entity],
       type: hb[:type],
-      category: hb[:category] || "coding",
-      project: hb[:project],
-      language: LanguageUtils.fill_missing_language(hb[:language], entity: hb[:entity]),
-      editor: hb[:editor].presence || user_agent_info[:editor].presence || parsed_user_agent[:editor].presence,
+      category: hb[:category].presence,
+      project: sanitize_project(hb[:project]),
+      language: hb[:language],
+      editor: derived_ai_editor || hb[:editor].presence || user_agent_info[:editor].presence || parsed_user_agent[:editor].presence,
       operating_system: hb[:operating_system].presence || user_agent_info[:os].presence || parsed_user_agent[:os].presence,
       machine: hb[:machine].presence || hb[:machine_name_id].presence,
       branch: hb[:branch],
@@ -170,8 +255,16 @@ class HeartbeatIngest
       project_root_count: hb[:project_root_count],
       source_type: Heartbeat.source_types.fetch("wakapi_import")
     }
-    attrs[:fields_hash] = Heartbeat.generate_fields_hash(attrs)
-    attrs
+    resolve_placeholders!(attrs, placeholder_state)
+    attrs[:language] = LanguageUtils.fill_missing_language(attrs[:language], entity: attrs[:entity])
+    attrs[:category] = default_category(attrs[:category], type: attrs[:type], language: attrs[:language])
+    model_attributes = validated_model_attributes(attrs)
+    normalized = model_attributes
+      .except("id", "fields_hash", "created_at", "updated_at", "time_epoch")
+      .symbolize_keys
+    normalized[:fields_hash] = Heartbeat.generate_fields_hash(model_attributes)
+    update_placeholder_state!(normalized, placeholder_state)
+    normalized
   end
 
   def flush_import_batch(seen_hashes)
@@ -218,7 +311,8 @@ class HeartbeatIngest
   end
 
   def normalize_epoch_time(value)
-    t = value.to_f
+    t = Float(value)
+    raise InvalidHeartbeatTime unless t.finite?
     return t if t >= EPOCH_SANE_MIN && t < EPOCH_SANE_MAX
 
     # ms / µs / ns-scaled epochs are mechanically repairable
@@ -226,13 +320,78 @@ class HeartbeatIngest
       scaled = t / scale
       return scaled if scaled >= EPOCH_SANE_MIN && scaled < EPOCH_SANE_MAX
     end
-    t
+
+    raise InvalidHeartbeatTime, "time must be Unix epoch seconds between #{EPOCH_SANE_MIN} and #{EPOCH_SANE_MAX - 1}"
+  rescue TypeError, ArgumentError => e
+    raise e if e.is_a?(InvalidHeartbeatTime)
+    raise InvalidHeartbeatTime, "time must be a Unix epoch timestamp"
   end
 
-  def parse_user_agent(user_agent)
-    return { editor: nil, os: nil } if user_agent.blank?
-    parsed = WakatimeService.parse_user_agent(user_agent)
-    { editor: parsed[:editor].presence, os: parsed[:os].presence }
+  def normalize_heartbeat_time(value)
+    if value.is_a?(String) && !value.strip.match?(/\A[+-]?(?:\d+(?:\.\d*)?|\.\d+)\z/)
+      normalize_epoch_time(Time.parse(value).to_f)
+    else
+      normalize_epoch_time(value)
+    end
+  rescue InvalidHeartbeatTime
+    raise
+  rescue TypeError, ArgumentError
+    raise InvalidHeartbeatTime, "time must be a Unix epoch timestamp or parseable date"
+  end
+
+  def validate_direct_time!(time)
+    return if time <= DIRECT_FUTURE_TOLERANCE.from_now.to_f
+
+    raise InvalidHeartbeatTime, "time must not be more than #{DIRECT_FUTURE_TOLERANCE.inspect} in the future"
+  end
+
+  def parse_user_agent(user_agent, category: nil)
+    return { editor: nil, os: nil, ai_model: nil } if user_agent.blank?
+    parsed = WakatimeService.parse_user_agent(user_agent, category:)
+    { editor: parsed[:editor].presence, os: parsed[:os].presence, ai_model: parsed[:ai_model].presence }
+  end
+
+  def default_category(category, type:, language:)
+    return category if category.present?
+    return "browsing" if %w[domain url].include?(type)
+    return "coding" if type == "file" && language.present?
+
+    nil
+  end
+
+  # `<<LAST_PROJECT>>` stays persisted by design, but language and branch need
+  # the last real project as context. This avoids turning browser time into a
+  # guessed project while preventing sentinel values from fragmenting reports.
+  def resolve_placeholders!(attrs, state)
+    context_project = attrs[:project] == LAST_PROJECT_SENTINEL ? state[:last_project] : attrs[:project]
+    return unless attrs[:language] == LAST_LANGUAGE_SENTINEL || attrs[:branch] == LAST_BRANCH_SENTINEL
+
+    context = placeholder_context_for(context_project, state)
+    attrs[:language] = context[:language] if attrs[:language] == LAST_LANGUAGE_SENTINEL
+    attrs[:branch] = context[:branch] if attrs[:branch] == LAST_BRANCH_SENTINEL
+  end
+
+  def placeholder_context_for(project, state)
+    return {} if project.blank?
+    return state[:contexts][project] if state[:contexts].key?(project)
+
+    state[:contexts][project] = {
+      language: @user.heartbeats.where(project: project)
+        .where.not(language: [ nil, "", LAST_LANGUAGE_SENTINEL ]).order(time: :desc).pick(:language),
+      branch: @user.heartbeats.where(project: project)
+        .where.not(branch: [ nil, "", LAST_BRANCH_SENTINEL ]).order(time: :desc).pick(:branch)
+    }
+  end
+
+  def update_placeholder_state!(attrs, state)
+    project = attrs[:project]
+    state[:last_project] = project if project.present? && project != LAST_PROJECT_SENTINEL
+    context_project = project == LAST_PROJECT_SENTINEL ? state[:last_project] : project
+    return if context_project.blank?
+
+    context = state[:contexts][context_project] ||= {}
+    context[:language] = attrs[:language] if attrs[:language].present? && attrs[:language] != LAST_LANGUAGE_SENTINEL
+    context[:branch] = attrs[:branch] if attrs[:branch].present? && attrs[:branch] != LAST_BRANCH_SENTINEL
   end
 
   def resolved_ja4
@@ -241,9 +400,17 @@ class HeartbeatIngest
     @resolved_ja4 = Ja4.resolve(@request_context[:ja4])
   end
 
+  def sanitize_project(project_name)
+    project_name&.gsub(/[[:cntrl:]]/, "")&.strip
+  end
+
   def queue_project_mapping(project_name)
-    return if project_name.blank?
-    Rails.cache.fetch("attempt_project_repo_mapping_job_#{@user.id}_#{project_name}", expires_in: 1.hour) { AttemptProjectRepoMappingJob.perform_later(@user.id, project_name) }
+    return if ProjectRepoMapping::IGNORED_PROJECTS.include?(project_name)
+
+    project_digest = Digest::SHA256.hexdigest(project_name)
+    Rails.cache.fetch("attempt_project_repo_mapping_job_#{@user.id}_#{project_digest}", expires_in: 1.hour) do
+      AttemptProjectRepoMappingJob.perform_later(@user.id, project_name)
+    end
   rescue => e
     Rails.error.report(e, handled: true, context: { message: "Error queuing project mapping" })
   end

--- a/app/services/heartbeat_ingest.rb
+++ b/app/services/heartbeat_ingest.rb
@@ -372,14 +372,17 @@ class HeartbeatIngest
 
   def placeholder_context_for(project, state)
     return {} if project.blank?
-    return state[:contexts][project] if state[:contexts].key?(project)
 
-    state[:contexts][project] = {
-      language: @user.heartbeats.where(project: project)
-        .where.not(language: [ nil, "", LAST_LANGUAGE_SENTINEL ]).order(time: :desc).pick(:language),
-      branch: @user.heartbeats.where(project: project)
+    context = state[:contexts][project] ||= {}
+    unless context.key?(:language)
+      context[:language] = @user.heartbeats.where(project: project)
+        .where.not(language: [ nil, "", LAST_LANGUAGE_SENTINEL ]).order(time: :desc).pick(:language)
+    end
+    unless context.key?(:branch)
+      context[:branch] = @user.heartbeats.where(project: project)
         .where.not(branch: [ nil, "", LAST_BRANCH_SENTINEL ]).order(time: :desc).pick(:branch)
-    }
+    end
+    context
   end
 
   def update_placeholder_state!(attrs, state)

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -6,7 +6,9 @@
 Rails.application.config.filter_parameters += [
   :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc,
   :_json, :hackatime, :heartbeat, :heartbeats,
+  :ai_input_tokens, :ai_line_changes, :ai_model, :ai_output_tokens, :ai_prompt_length,
+  :ai_session, :ai_subscription_plan,
   :branch, :category, :cursorpos, :dependencies, :editor, :entity, :is_write, :language,
-  :line_additions, :line_deletions, :lineno, :lines, :machine, :operating_system,
+  :human_line_changes, :line_additions, :line_deletions, :lineno, :lines, :machine, :operating_system,
   :plugin, :project, :project_root_count, :time, :type, :user_agent
 ]

--- a/db/migrate/20260722135825_add_ai_telemetry_to_heartbeats.rb
+++ b/db/migrate/20260722135825_add_ai_telemetry_to_heartbeats.rb
@@ -1,0 +1,14 @@
+class AddAiTelemetryToHeartbeats < ActiveRecord::Migration[8.1]
+  def change
+    change_table :heartbeats, bulk: true do |t|
+      t.string :ai_model
+      t.string :ai_session
+      t.string :ai_subscription_plan
+      t.bigint :ai_input_tokens
+      t.bigint :ai_output_tokens
+      t.integer :ai_prompt_length
+      t.integer :ai_line_changes
+      t.integer :human_line_changes
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_20_232900) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_22_135825) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -305,6 +305,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_20_232900) do
   end
 
   create_table "heartbeats", force: :cascade do |t|
+    t.bigint "ai_input_tokens"
+    t.integer "ai_line_changes"
+    t.string "ai_model"
+    t.bigint "ai_output_tokens"
+    t.integer "ai_prompt_length"
+    t.string "ai_session"
+    t.string "ai_subscription_plan"
     t.string "branch"
     t.string "category"
     t.datetime "created_at", null: false
@@ -314,6 +321,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_20_232900) do
     t.string "editor"
     t.string "entity"
     t.text "fields_hash"
+    t.integer "human_line_changes"
     t.inet "ip_address"
     t.boolean "is_write"
     t.integer "ja4_id"

--- a/lib/wakatime_service.rb
+++ b/lib/wakatime_service.rb
@@ -4,6 +4,20 @@ include ApplicationHelper
 include ErrorReporting
 
 class WakatimeService
+  USER_AGENT_MIDDLEWARES = %w[wakatime-ls wakatime-cli].freeze
+  USER_AGENT_OS_PRODUCTS = %w[linux windows macos darwin win mac wsl].freeze
+  AI_AGENT_PRODUCTS = %w[
+    amp antigravity-cli antigravity-desktop antigravity-ide claude claude-code claudecode
+    codex codex-cli continue cody copilot cursor gemini github-copilot
+    github-copilot-cli goose kiro opencode opencode-cli pi qoder qwen-code
+    qwen-code-cli roo-code windsurf
+  ].freeze
+  UNAMBIGUOUS_AI_AGENT_PREFIXES = %w[
+    amp antigravity-cli antigravity-desktop antigravity-ide claude-code claudecode
+    codex-cli copilot github-copilot github-copilot-cli opencode-cli qwen-code-cli
+  ].freeze
+  AI_MODEL_PRODUCTS_WITH_EDITOR_NAME_COLLISIONS = %w[claude codex gemini].freeze
+
   def initialize(user: nil, specific_filters: [], allow_cache: true, limit: 10, start_date: nil, end_date: nil, scope: nil, boundary_aware: false, valid_timestamps_only: false, exclude_categories: [])
     @scope = scope || Heartbeat.all
     @scope = @scope.with_valid_timestamps if valid_timestamps_only
@@ -107,44 +121,211 @@ class WakatimeService
     result
   end
 
-  def self.parse_user_agent(user_agent)
-    # Based on https://github.com/muety/wakapi/blob/b3668085c01dc0724d8330f4d51efd5b5aecaeb2/utils/http.go#L89
-
-    # Regex pattern to match wakatime client user agents
-    user_agent_pattern = /wakatime\/[^ ]+ \(([^)]+)\)(?: [^ ]+ ([^\/]+)(?:\/([^\/]+))?)?/
-
+  def self.parse_user_agent(user_agent, category: nil)
     return { os: "", editor: "", err: "failed to parse user agent string" } if user_agent.blank?
 
-    if matches = user_agent.match(user_agent_pattern)
-      os = matches[1].split("-").first
+    # Everything after the platform is an ordered editor/plugin chain, possibly
+    # preceded by a runtime and a model token from an AI transcript parser.
+    if matches = user_agent.match(/\Awakatime\/\S*\s+\(([^)]+)\)(?:\s+(.*))?\z/i)
+      products = matches[2].to_s.split
+      products.shift if runtime_product?(user_agent_product(products.first).downcase)
+      ai_model = nil
 
-      editor = matches[2]
-      editor ||= ""
-
-      { os: os, editor: editor, err: nil }
-    else
-      # Try parsing as browser user agent as fallback
-      if browser_ua = user_agent.match(/^([^\/]+)\/([^\/\s]+)/)
-        # If "wakatime" is present, assume it's the browser extension
-        if user_agent.include?("wakatime") then
-            full_os = user_agent.split(" ")[1]
-            if full_os.present?
-              os = full_os.include?("_") ? full_os.split("_")[0] : full_os
-              { os: os, editor: browser_ua[1].downcase, err: nil }
-            else
-              { os: "", editor: "", err: "failed to parse user agent string" }
-            end
-        else
-          { os: browser_ua[1], editor: browser_ua[2], err: nil }
-        end
-      else
-        { os: "", editor: "", err: "failed to parse user agent string" }
+      model_prefixed = ai_category?(category) && model_first_product_chain?(products)
+      if model_prefixed
+        ai_model = products.shift
       end
+
+      return {
+        os: normalize_os(matches[1], user_agent:),
+        editor: extract_editor(products, skip_ai_agents: !model_prefixed),
+        ai_model:,
+        err: nil
+      }
     end
+
+    parse_browser_or_legacy_user_agent(user_agent, category:)
   rescue => e
     report_error(e, message: "Error parsing user agent string")
     { os: "", editor: "", err: "failed to parse user agent string" }
   end
+
+  def self.ai_category?(category) = category.to_s.casecmp?("ai coding")
+
+  def self.model_first_product_chain?(products)
+    meaningful_products = products.reject do |token|
+      product = user_agent_product(token)
+      product.blank? || product.start_with?("(")
+    end
+    return false if meaningful_products.length < 2
+
+    first_product_original = user_agent_product(meaningful_products.first)
+    first_product = first_product_original.downcase
+    second_product = user_agent_product(meaningful_products.second).downcase
+
+    # Plugin products identify editors. They are never model tokens.
+    return false if plugin_product?(meaningful_products.first)
+
+    # A normal editor chain commonly ends with its own plugin. This does not
+    # need an editor allowlist, so a newly supported editor cannot accidentally
+    # become a model merely because Hackatime has not heard of it yet.
+    return false if meaningful_products.any? { plugin_product?(_1) && plugin_base(_1) == first_product }
+
+    # Claude, Codex and Gemini are both model families and standalone clients.
+    # In an AI category, a lowercase token is a model unless its own matching
+    # plugin proves that it is the editor.
+    return true if AI_MODEL_PRODUCTS_WITH_EDITOR_NAME_COLLISIONS.include?(first_product) &&
+      first_product_original == first_product && second_product.present?
+
+    # AI parsers prepend their own product even when a transcript has no model.
+    # Keep these out of ai_model while retaining them as a last-resort editor.
+    return false if AI_AGENT_PRODUCTS.include?(first_product)
+
+    # A two-product `editor vscode-wakatime` chain is also normal for VS Code
+    # forks (Cursor, Kiro, and future editors). A model-prefixed chain has an
+    # editor/parser token in addition to this fallback plugin.
+    return false if meaningful_products.length == 2 && plugin_product?(meaningful_products.second)
+
+    true
+  end
+
+  def self.user_agent_product(token) = token.to_s.split("/", 2).first
+
+  def self.extract_editor(products, skip_ai_agents: false)
+    skipped_ai_agent = nil
+    skip_known_agents = skip_ai_agents && products.length > 2
+    first_candidate = true
+
+    products.each do |token|
+      product = user_agent_product(token)
+      next if product.blank? || product.start_with?("(")
+
+      product_downcase = product.downcase
+      next if product_downcase == "wakatime" || USER_AGENT_MIDDLEWARES.include?(product_downcase) || runtime_product?(product_downcase)
+
+      if plugin_product?(product)
+        candidate = plugin_base(product)
+        next if USER_AGENT_OS_PRODUCTS.include?(candidate)
+
+        return normalize_editor(candidate)
+      end
+
+      skip_agent = first_candidate || UNAMBIGUOUS_AI_AGENT_PREFIXES.include?(product_downcase)
+      if skip_known_agents && skip_agent && AI_AGENT_PRODUCTS.include?(product_downcase)
+        skipped_ai_agent ||= product_downcase
+        first_candidate = false
+        next
+      end
+
+      return normalize_editor(product_downcase)
+    end
+
+    normalize_editor(skipped_ai_agent || "")
+  end
+
+  def self.plugin_product?(token)
+    product = user_agent_product(token)
+    product.casecmp?("wakatime.nvim") || product.match?(/[-_](?:waka|hacka)time\z/i)
+  end
+
+  def self.plugin_base(token)
+    product = user_agent_product(token)
+    return "neovim" if product.casecmp?("wakatime.nvim")
+
+    product.sub(/[-_](?:waka|hacka)time\z/i, "").downcase
+  end
+
+  def self.normalize_editor(editor)
+    case editor
+    when "github-copilot-cli" then "copilot-cli"
+    when "ktexteditor" then "kate"
+    when "vs-code" then "vscode"
+    else editor
+    end
+  end
+
+  def self.runtime_product?(product)
+    product == "python" || product == "go" || product.match?(/\A(?:python|go)\d/)
+  end
+
+  def self.normalize_os(platform, user_agent:)
+    return "wsl" if user_agent.match?(/-wsl2-/i)
+
+    candidate = platform.to_s.sub(/\A\(/, "").split(/[\s)_-]/).first.to_s.downcase
+    case candidate
+    when "win", "windows" then "windows"
+    when "darwin", "mac", "macos" then "macos"
+    else candidate
+    end
+  end
+
+  def self.parse_browser_or_legacy_user_agent(user_agent, category: nil)
+    browser = if user_agent.match?(/\b(?:edg|edge)\//i)
+      "edge"
+    elsif user_agent.match?(/\bfirefox\//i)
+      "firefox"
+    elsif user_agent.match?(/\b(?:chrome|chromium)\//i)
+      "chrome"
+    elsif user_agent.match?(/\Ahbuilder x\//i)
+      "hbuilder-x"
+    end
+
+    if browser
+      os = if user_agent.match?(/windows|win_/i)
+        "windows"
+      elsif user_agent.match?(/mac(?:intosh|_| )|darwin/i)
+        "macos"
+      elsif user_agent.match?(/linux/i)
+        "linux"
+      else
+        ""
+      end
+      return { os:, editor: browser, ai_model: nil, err: nil }
+    end
+
+    os = direct_user_agent_os(user_agent)
+    products = user_agent.gsub(/\([^)]*\)/, " ").split.reject { direct_os_product?(_1) }
+    has_parseable_product = products.any? { _1.include?("/") || plugin_product?(_1) }
+    return { os: "", editor: "", err: "failed to parse user agent string" } unless has_parseable_product
+
+    model_prefixed = ai_category?(category) && model_first_product_chain?(products)
+    ai_model = model_prefixed ? products.shift : nil
+
+    # Some integrations put an editor name containing spaces before their
+    # plugin product. Splitting that name is ambiguous, while the plugin suffix
+    # provides an exact and future-compatible editor identifier.
+    malformed_leading_product = !ai_category?(category) && products.first.present? &&
+      !products.first.include?("/") && !plugin_product?(products.first)
+    editor = if products.one? && USER_AGENT_MIDDLEWARES.include?(user_agent_product(products.first).downcase)
+      normalize_editor(user_agent_product(products.first).downcase)
+    elsif malformed_leading_product
+      plugin = products.find { plugin_product?(_1) }
+      normalize_editor(plugin ? plugin_base(plugin) : "")
+    else
+      extract_editor(products, skip_ai_agents: ai_category?(category) && !model_prefixed)
+    end
+
+    return { os:, editor:, ai_model:, err: nil } if editor.present?
+
+    { os: "", editor: "", err: "failed to parse user agent string" }
+  end
+
+  def self.direct_user_agent_os(user_agent)
+    return "wsl" if user_agent.match?(/wsl2?/i)
+    return "windows" if user_agent.match?(/windows|win_/i)
+    return "macos" if user_agent.match?(/macintosh|mac[_ -]?os|darwin/i)
+    return "linux" if user_agent.match?(/linux/i)
+
+    ""
+  end
+
+  def self.direct_os_product?(token)
+    token.to_s.match?(/\A(?:windows|win|linux|darwin|macos|mac)(?:[_-].*)?\z/i)
+  end
+
+  private_class_method :ai_category?, :model_first_product_chain?, :user_agent_product,
+    :extract_editor, :plugin_product?, :plugin_base, :normalize_editor, :runtime_product?, :normalize_os,
+    :parse_browser_or_legacy_user_agent, :direct_user_agent_os, :direct_os_product?
 
 
   def transform_display_name(group_by, key)

--- a/lib/wakatime_service.rb
+++ b/lib/wakatime_service.rb
@@ -128,7 +128,7 @@ class WakatimeService
     # preceded by a runtime and a model token from an AI transcript parser.
     if matches = user_agent.match(/\Awakatime\/\S*\s+\(([^)]+)\)(?:\s+(.*))?\z/i)
       products = matches[2].to_s.split
-      products.shift if runtime_product?(user_agent_product(products.first).downcase)
+      products.shift if runtime_product?(user_agent_product(products.first).to_s.downcase)
       ai_model = nil
 
       model_prefixed = ai_category?(category) && model_first_product_chain?(products)

--- a/lib/wakatime_service.rb
+++ b/lib/wakatime_service.rb
@@ -133,7 +133,7 @@ class WakatimeService
 
       model_prefixed = ai_category?(category) && model_first_product_chain?(products)
       if model_prefixed
-        ai_model = products.shift
+        ai_model = shift_meaningful_product!(products)
       end
 
       return {
@@ -153,10 +153,7 @@ class WakatimeService
   def self.ai_category?(category) = category.to_s.casecmp?("ai coding")
 
   def self.model_first_product_chain?(products)
-    meaningful_products = products.reject do |token|
-      product = user_agent_product(token)
-      product.blank? || product.start_with?("(")
-    end
+    meaningful_products = products.select { |token| meaningful_product?(token) }
     return false if meaningful_products.length < 2
 
     first_product_original = user_agent_product(meaningful_products.first)
@@ -190,6 +187,16 @@ class WakatimeService
   end
 
   def self.user_agent_product(token) = token.to_s.split("/", 2).first
+
+  def self.meaningful_product?(token)
+    product = user_agent_product(token)
+    product.present? && !product.start_with?("(")
+  end
+
+  def self.shift_meaningful_product!(products)
+    index = products.index { |token| meaningful_product?(token) }
+    products.delete_at(index) if index
+  end
 
   def self.extract_editor(products, skip_ai_agents: false)
     skipped_ai_agent = nil
@@ -289,7 +296,7 @@ class WakatimeService
     return { os: "", editor: "", err: "failed to parse user agent string" } unless has_parseable_product
 
     model_prefixed = ai_category?(category) && model_first_product_chain?(products)
-    ai_model = model_prefixed ? products.shift : nil
+    ai_model = model_prefixed ? shift_meaningful_product!(products) : nil
 
     # Some integrations put an editor name containing spaces before their
     # plugin product. Splitting that name is ambiguous, while the plugin suffix
@@ -324,6 +331,7 @@ class WakatimeService
   end
 
   private_class_method :ai_category?, :model_first_product_chain?, :user_agent_product,
+    :meaningful_product?, :shift_meaningful_product!,
     :extract_editor, :plugin_product?, :plugin_base, :normalize_editor, :runtime_product?, :normalize_os,
     :parse_browser_or_legacy_user_agent, :direct_user_agent_os, :direct_os_product?
 

--- a/lib/wakatime_service.rb
+++ b/lib/wakatime_service.rb
@@ -133,7 +133,7 @@ class WakatimeService
 
       model_prefixed = ai_category?(category) && model_first_product_chain?(products)
       if model_prefixed
-        ai_model = shift_meaningful_product!(products)
+        ai_model = shift_first_non_metadata_product!(products)
       end
 
       return {
@@ -193,7 +193,7 @@ class WakatimeService
     product.present? && !product.start_with?("(")
   end
 
-  def self.shift_meaningful_product!(products)
+  def self.shift_first_non_metadata_product!(products)
     index = products.index { |token| meaningful_product?(token) }
     products.delete_at(index) if index
   end
@@ -296,7 +296,7 @@ class WakatimeService
     return { os: "", editor: "", err: "failed to parse user agent string" } unless has_parseable_product
 
     model_prefixed = ai_category?(category) && model_first_product_chain?(products)
-    ai_model = model_prefixed ? shift_meaningful_product!(products) : nil
+    ai_model = model_prefixed ? shift_first_non_metadata_product!(products) : nil
 
     # Some integrations put an editor name containing spaces before their
     # plugin product. Splitting that name is ambiguous, while the plugin suffix
@@ -331,7 +331,7 @@ class WakatimeService
   end
 
   private_class_method :ai_category?, :model_first_product_chain?, :user_agent_product,
-    :meaningful_product?, :shift_meaningful_product!,
+    :meaningful_product?, :shift_first_non_metadata_product!,
     :extract_editor, :plugin_product?, :plugin_base, :normalize_editor, :runtime_product?, :normalize_os,
     :parse_browser_or_legacy_user_agent, :direct_user_agent_os, :direct_os_product?
 

--- a/spec/requests/api/hackatime/v1/compatibility_spec.rb
+++ b/spec/requests/api/hackatime/v1/compatibility_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe 'Api::Hackatime::V1::Compatibility', type: :request do
             time: { type: :number, example: 1710946200.0, description: 'Unix timestamp (seconds, float)' },
             project: { type: :string, example: 'hackatime' },
             branch: { type: :string, example: 'main' },
+            ai_model: { type: :string, example: 'gpt/5.3-codex' },
+            ai_session: { type: :string, example: 'session-123' },
+            ai_subscription_plan: { type: :string, example: 'pro' },
+            ai_input_tokens: { type: :integer, format: :int64, example: 1200 },
+            ai_output_tokens: { type: :integer, format: :int64, example: 350 },
+            ai_prompt_length: { type: :integer, example: 240 },
+            ai_line_changes: { type: :integer, example: 18 },
+            human_line_changes: { type: :integer, example: 7 },
             language: { type: :string, example: 'Ruby' },
             is_write: { type: :boolean, example: true },
             lineno: { type: :integer, example: 42 },
@@ -54,6 +62,14 @@ RSpec.describe 'Api::Hackatime::V1::Compatibility', type: :request do
             time: { type: :number, example: 1710946200.0 },
             project: { type: :string, nullable: true, example: 'hackatime' },
             branch: { type: :string, nullable: true, example: 'main' },
+            ai_model: { type: :string, nullable: true, example: 'gpt/5.3-codex' },
+            ai_session: { type: :string, nullable: true, example: 'session-123' },
+            ai_subscription_plan: { type: :string, nullable: true, example: 'pro' },
+            ai_input_tokens: { type: :integer, format: :int64, nullable: true, example: 1200 },
+            ai_output_tokens: { type: :integer, format: :int64, nullable: true, example: 350 },
+            ai_prompt_length: { type: :integer, nullable: true, example: 240 },
+            ai_line_changes: { type: :integer, nullable: true, example: 18 },
+            human_line_changes: { type: :integer, nullable: true, example: 7 },
             language: { type: :string, nullable: true, example: 'Ruby' },
             is_write: { type: :boolean, nullable: true, example: true },
             lineno: { type: :integer, nullable: true, example: 42 },
@@ -76,6 +92,19 @@ RSpec.describe 'Api::Hackatime::V1::Compatibility', type: :request do
         let(:id) { 'current' }
         let(:heartbeats) { [] }
         schema type: :object, properties: { error: { type: :string, example: 'No data provided...' } }
+        run_test!
+      end
+
+      response(422, 'heartbeat rejected') do
+        let(:Authorization) { "Bearer dev-api-key-12345" }
+        let(:api_key) { "dev-api-key-12345" }
+        let(:id) { 'current' }
+        let(:heartbeats) { [ { entity: 'file.rb', time: 2.hours.from_now.to_f } ] }
+        schema type: :object,
+          properties: {
+            error: { type: :string, example: 'time must not be more than 1 hour in the future' },
+            type: { type: :string, example: 'HeartbeatIngest::InvalidHeartbeatTime' }
+          }
         run_test!
       end
 
@@ -138,6 +167,14 @@ RSpec.describe 'Api::Hackatime::V1::Compatibility', type: :request do
             time: { type: :number, example: 1710946200.0 },
             project: { type: :string, example: 'hackatime' },
             branch: { type: :string, example: 'main' },
+            ai_model: { type: :string, example: 'gpt/5.3-codex' },
+            ai_session: { type: :string, example: 'session-123' },
+            ai_subscription_plan: { type: :string, example: 'pro' },
+            ai_input_tokens: { type: :integer, format: :int64, example: 1200 },
+            ai_output_tokens: { type: :integer, format: :int64, example: 350 },
+            ai_prompt_length: { type: :integer, example: 240 },
+            ai_line_changes: { type: :integer, example: 18 },
+            human_line_changes: { type: :integer, example: 7 },
             language: { type: :string, example: 'Ruby' },
             is_write: { type: :boolean, example: true },
             lineno: { type: :integer, example: 42 },

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -31,6 +31,8 @@ paths:
           description: accepted
         '400':
           description: no data provided
+        '422':
+          description: heartbeat rejected
         '401':
           description: unauthorized
         '403':
@@ -63,6 +65,32 @@ paths:
                   branch:
                     type: string
                     example: main
+                  ai_model:
+                    type: string
+                    example: gpt/5.3-codex
+                  ai_session:
+                    type: string
+                    example: session-123
+                  ai_subscription_plan:
+                    type: string
+                    example: pro
+                  ai_input_tokens:
+                    type: integer
+                    format: int64
+                    example: 1200
+                  ai_output_tokens:
+                    type: integer
+                    format: int64
+                    example: 350
+                  ai_prompt_length:
+                    type: integer
+                    example: 240
+                  ai_line_changes:
+                    type: integer
+                    example: 18
+                  human_line_changes:
+                    type: integer
+                    example: 7
                   language:
                     type: string
                     example: Ruby
@@ -170,6 +198,32 @@ paths:
                   branch:
                     type: string
                     example: main
+                  ai_model:
+                    type: string
+                    example: gpt/5.3-codex
+                  ai_session:
+                    type: string
+                    example: session-123
+                  ai_subscription_plan:
+                    type: string
+                    example: pro
+                  ai_input_tokens:
+                    type: integer
+                    format: int64
+                    example: 1200
+                  ai_output_tokens:
+                    type: integer
+                    format: int64
+                    example: 350
+                  ai_prompt_length:
+                    type: integer
+                    example: 240
+                  ai_line_changes:
+                    type: integer
+                    example: 18
+                  human_line_changes:
+                    type: integer
+                    example: 7
                   language:
                     type: string
                     example: Ruby

--- a/test/controllers/api/hackatime/v1/hackatime_controller_test.rb
+++ b/test/controllers/api/hackatime/v1/hackatime_controller_test.rb
@@ -7,6 +7,7 @@ class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationT
     api_key = user.api_keys.create!(name: "primary")
 
     payload = {
+      dependencies: [ "rails", "pg" ],
       entity: "src/main.rb",
       plugin: "vscode/1.0.0",
       project: "hackatime",
@@ -28,6 +29,7 @@ class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationT
     assert_equal user.id, heartbeat.user_id
     assert_equal "vscode/1.0.0", heartbeat.user_agent
     assert_equal "coding", heartbeat.category
+    assert_equal [ "rails", "pg" ], heartbeat.dependencies
   end
 
   test "single heartbeat stores the Cloudflare JA4 header" do
@@ -64,6 +66,7 @@ class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationT
       category: "coding",
       time: 1.hour.ago.to_f,
       language: "Ruby",
+      project: "hackatime",
       source_type: :direct_entry
     )
 
@@ -156,7 +159,7 @@ class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationT
     assert_equal "Ruby", heartbeat.language
   end
 
-  test "single heartbeat ignores unknown fields like raw_data and ai_line_changes" do
+  test "single heartbeat ignores unknown fields and preserves AI telemetry" do
     user = User.create!(timezone: "UTC")
     api_key = user.api_keys.create!(name: "primary")
 
@@ -167,6 +170,12 @@ class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationT
       time: Time.current.to_f,
       type: "file",
       raw_data: '{"some": "data"}',
+      ai_model: "gpt/5.6",
+      ai_session: "session-123",
+      ai_subscription_plan: "pro",
+      ai_input_tokens: 1_000,
+      ai_output_tokens: 250,
+      ai_prompt_length: 80,
       ai_line_changes: 5,
       human_line_changes: 10,
       completely_bogus_field: "should be ignored"
@@ -185,9 +194,17 @@ class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationT
     heartbeat = Heartbeat.order(:id).last
     assert_equal "src/main.rb", heartbeat.entity
     assert_equal "hackatime", heartbeat.project
+    assert_equal "gpt/5.6", heartbeat.ai_model
+    assert_equal "session-123", heartbeat.ai_session
+    assert_equal "pro", heartbeat.ai_subscription_plan
+    assert_equal 1_000, heartbeat.ai_input_tokens
+    assert_equal 250, heartbeat.ai_output_tokens
+    assert_equal 80, heartbeat.ai_prompt_length
+    assert_equal 5, heartbeat.ai_line_changes
+    assert_equal 10, heartbeat.human_line_changes
   end
 
-  test "bulk heartbeat ignores unknown fields like raw_data and ai_line_changes" do
+  test "bulk heartbeat ignores unknown fields and preserves AI telemetry" do
     user = User.create!(timezone: "UTC")
     api_key = user.api_keys.create!(name: "primary")
 
@@ -199,6 +216,7 @@ class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationT
         time: Time.current.to_f,
         type: "file",
         raw_data: '{"some": "data"}',
+        ai_session: "session-456",
         ai_line_changes: 3,
         human_line_changes: 7
       }
@@ -217,6 +235,9 @@ class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationT
     heartbeat = Heartbeat.order(:id).last
     assert_equal "src/first.rb", heartbeat.entity
     assert_equal "hackatime", heartbeat.project
+    assert_equal "session-456", heartbeat.ai_session
+    assert_equal 3, heartbeat.ai_line_changes
+    assert_equal 7, heartbeat.human_line_changes
   end
 
   test "duplicate heartbeat with different ip returns existing record" do
@@ -259,7 +280,9 @@ class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationT
         }
     end
     assert_response :accepted
-    assert_equal heartbeat.id, JSON.parse(response.body)["id"]
+    response_heartbeat = JSON.parse(response.body)
+    assert_equal heartbeat.id, response_heartbeat.fetch("id")
+    assert_equal "src/main.rb", response_heartbeat.fetch("entity")
     assert_no_match(/RecordNotUnique|duplicate key|unique/i, log_output.string)
   ensure
     Rails.logger = previous_logger if previous_logger
@@ -270,6 +293,7 @@ class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationT
     api_key = user.api_keys.create!(name: "primary")
 
     payload = [ {
+      dependencies: [ "rack", "puma" ],
       entity: "src/main.rb",
       plugin: "zed/1.0.0",
       project: "hackatime",
@@ -291,5 +315,74 @@ class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationT
     assert_equal user.id, heartbeat.user_id
     assert_equal "zed/1.0.0", heartbeat.user_agent
     assert_equal "coding", heartbeat.category
+    assert_equal [ "rack", "puma" ], heartbeat.dependencies
+  end
+
+  test "single heartbeat returns unprocessable entity when ingestion fails" do
+    user = User.create!(timezone: "UTC")
+    api_key = user.api_keys.create!(name: "primary")
+
+    assert_no_difference("Heartbeat.count") do
+      post "/api/hackatime/v1/users/current/heartbeats",
+        params: { entity: "src/main.rb", time: 2026, type: "file" }.to_json,
+        headers: {
+          "Authorization" => "Bearer #{api_key.token}",
+          "CONTENT_TYPE" => "text/plain"
+        }
+    end
+
+    assert_response :unprocessable_entity
+    assert_equal "HeartbeatIngest::InvalidHeartbeatTime", JSON.parse(response.body)["type"]
+  end
+
+  test "bulk text plain heartbeat rejects a non-array payload" do
+    user = User.create!(timezone: "UTC")
+    api_key = user.api_keys.create!(name: "primary")
+
+    assert_no_difference("Heartbeat.count") do
+      post "/api/hackatime/v1/users/current/heartbeats.bulk",
+        params: { entity: "src/main.rb", time: Time.current.to_f, type: "file" }.to_json,
+        headers: {
+          "Authorization" => "Bearer #{api_key.token}",
+          "CONTENT_TYPE" => "text/plain"
+        }
+    end
+
+    assert_response :bad_request
+  end
+
+  test "bulk heartbeat reports non-object array items without discarding valid items" do
+    user = User.create!(timezone: "UTC")
+    api_key = user.api_keys.create!(name: "primary")
+
+    assert_difference("Heartbeat.count", 1) do
+      post "/api/hackatime/v1/users/current/heartbeats.bulk",
+        params: [ "not-a-heartbeat", { entity: "src/main.rb", time: Time.current.to_f, type: "file" } ].to_json,
+        headers: {
+          "Authorization" => "Bearer #{api_key.token}",
+          "CONTENT_TYPE" => "text/plain"
+        }
+    end
+
+    assert_response :created
+    responses = JSON.parse(response.body).fetch("responses")
+    assert_equal 422, responses.first.last
+    assert_equal 201, responses.last.last
+  end
+
+  test "single text plain heartbeat rejects a scalar payload" do
+    user = User.create!(timezone: "UTC")
+    api_key = user.api_keys.create!(name: "primary")
+
+    assert_no_difference("Heartbeat.count") do
+      post "/api/hackatime/v1/users/current/heartbeats",
+        params: "42",
+        headers: {
+          "Authorization" => "Bearer #{api_key.token}",
+          "CONTENT_TYPE" => "text/plain"
+        }
+    end
+
+    assert_response :bad_request
   end
 end

--- a/test/controllers/my/project_repo_mappings_controller_test.rb
+++ b/test/controllers/my/project_repo_mappings_controller_test.rb
@@ -57,6 +57,8 @@ class My::ProjectRepoMappingsControllerTest < ActionDispatch::IntegrationTest
 
   test "index supports archived view state" do
     user = User.create!(timezone: "UTC")
+    user.project_repo_mappings.create!(project_name: "alpha")
+    create_project_heartbeats(user, "alpha")
     mapping = user.project_repo_mappings.create!(project_name: "beta")
     mapping.archive!
     create_project_heartbeats(user, "beta")
@@ -71,6 +73,7 @@ class My::ProjectRepoMappingsControllerTest < ActionDispatch::IntegrationTest
     page = inertia_page
     assert_equal true, page.dig("props", "show_archived")
     assert_equal 1, page.dig("props", "total_projects")
+    assert_equal [ "projects_data" ], page.dig("deferredProps", "default")
   end
 
   private

--- a/test/jobs/heartbeat_export_job_test.rb
+++ b/test/jobs/heartbeat_export_job_test.rb
@@ -21,6 +21,16 @@ class HeartbeatExportJobTest < ActiveJob::TestCase
     second_time = Time.utc(2026, 2, 12, 12, 0, 0)
 
     hb1 = create_heartbeat(at_time: first_time, entity: "src/first.rb")
+    hb1.update!(
+      ai_input_tokens: 1_000,
+      ai_line_changes: 12,
+      ai_model: "opus/4-8",
+      ai_output_tokens: 250,
+      ai_prompt_length: 80,
+      ai_session: "session-123",
+      ai_subscription_plan: "pro",
+      human_line_changes: 4
+    )
     hb2 = create_heartbeat(at_time: second_time, entity: "src/second.rb")
 
     assert_difference -> { ActiveStorage::Blob.count }, 1 do
@@ -47,7 +57,16 @@ class HeartbeatExportJobTest < ActiveJob::TestCase
     assert_equal 2, payload.dig("export_info", "total_heartbeats")
     assert_equal @user.heartbeats.order(time: :asc).duration_seconds, payload.dig("export_info", "total_duration_seconds")
     assert_equal [ hb1.id, hb2.id ], payload.fetch("heartbeats").map { |row| row.fetch("id") }
-    assert_equal "src/first.rb", payload.fetch("heartbeats").first.fetch("entity")
+    first_heartbeat = payload.fetch("heartbeats").first
+    assert_equal "src/first.rb", first_heartbeat.fetch("entity")
+    assert_equal "opus/4-8", first_heartbeat.fetch("ai_model")
+    assert_equal "session-123", first_heartbeat.fetch("ai_session")
+    assert_equal "pro", first_heartbeat.fetch("ai_subscription_plan")
+    assert_equal 1_000, first_heartbeat.fetch("ai_input_tokens")
+    assert_equal 250, first_heartbeat.fetch("ai_output_tokens")
+    assert_equal 80, first_heartbeat.fetch("ai_prompt_length")
+    assert_equal 12, first_heartbeat.fetch("ai_line_changes")
+    assert_equal 4, first_heartbeat.fetch("human_line_changes")
     assert_equal "src/second.rb", payload.fetch("heartbeats").last.fetch("entity")
 
     assert_includes mail.text_part.body.decoded, "/rails/active_storage/"

--- a/test/lib/wakatime_service_test.rb
+++ b/test/lib/wakatime_service_test.rb
@@ -10,15 +10,25 @@ class WakatimeServiceTest < Minitest::Test
   def test_parse_user_agent_with_vscode_wakatime_client
     user_agent = "wakatime/v1.0.0 (darwin-arm64) go1.0.0 vscode/1.0.0 vscode-wakatime/1.0.0"
     result = WakatimeService.parse_user_agent(user_agent)
-    assert_equal "darwin", result[:os]
+    assert_equal "macos", result[:os]
     assert_equal "vscode", result[:editor]
     assert_nil result[:error]
+  end
+
+  def test_parse_user_agent_without_a_runtime_token
+    result = WakatimeService.parse_user_agent(
+      "wakatime/1.0 (linux-x86_64) vscode/1.90"
+    )
+
+    assert_equal "linux", result[:os]
+    assert_equal "vscode", result[:editor]
+    assert_nil result[:ai_model]
   end
 
   def test_parse_user_agent_with_GitHub_Desktop
     user_agent = "wakatime/v1.0.0 (darwin-arm64) go1.0.0 github-desktop/1.0.0"
     result = WakatimeService.parse_user_agent(user_agent)
-    assert_equal "darwin", result[:os]
+    assert_equal "macos", result[:os]
     assert_equal "github-desktop", result[:editor]
     assert_nil result[:error]
   end
@@ -26,7 +36,7 @@ class WakatimeServiceTest < Minitest::Test
   def test_parse_user_agent_with_Figma
     user_agent = "wakatime/v1.0.0 (darwin-arm64) go1.0.0 figma/1.0.0"
     result = WakatimeService.parse_user_agent(user_agent)
-    assert_equal "darwin", result[:os]
+    assert_equal "macos", result[:os]
     assert_equal "figma", result[:editor]
     assert_nil result[:error]
   end
@@ -34,7 +44,7 @@ class WakatimeServiceTest < Minitest::Test
   def test_parse_user_agent_with_Terminal
     user_agent = "wakatime/v1.0.0 (darwin-arm64) go1.0.0 terminal/1.0.0"
     result = WakatimeService.parse_user_agent(user_agent)
-    assert_equal "darwin", result[:os]
+    assert_equal "macos", result[:os]
     assert_equal "terminal", result[:editor]
     assert_nil result[:error]
   end
@@ -42,7 +52,7 @@ class WakatimeServiceTest < Minitest::Test
   def test_parse_user_agent_with_vim
     user_agent = "wakatime/v1.0.0 (darwin-arm64) go1.0.0 vim/1.0.0"
     result = WakatimeService.parse_user_agent(user_agent)
-    assert_equal "darwin", result[:os]
+    assert_equal "macos", result[:os]
     assert_equal "vim", result[:editor]
     assert_nil result[:error]
   end
@@ -58,9 +68,263 @@ class WakatimeServiceTest < Minitest::Test
   def test_parse_user_agent_with_Cursor
     user_agent = "wakatime/v1.0.0 (darwin-arm64) go1.0.0 cursor/1.0.0"
     result = WakatimeService.parse_user_agent(user_agent)
-    assert_equal "darwin", result[:os]
+    assert_equal "macos", result[:os]
     assert_equal "cursor", result[:editor]
     assert_nil result[:error]
+  end
+
+  def test_parse_user_agent_separates_ai_model_from_claude_code_editor
+    user_agent = "wakatime/v2.21.4 (darwin-25.5.0-arm64) go1.26.4 opus/4-8 claude-code/2.1.202"
+
+    result = WakatimeService.parse_user_agent(user_agent, category: "ai coding")
+
+    assert_equal "macos", result[:os]
+    assert_equal "claude-code", result[:editor]
+    assert_equal "opus/4-8", result[:ai_model]
+  end
+
+  def test_parse_user_agent_separates_ai_model_from_copilot_cli_editor
+    user_agent = "wakatime/v2.21.4 (windows-10.0.19045.5011-x86_64) go1.26.4 gpt/5.3-codex github-copilot-cli/1.0.68 copilot/1.0.68 cursor/1.105.1 vscode-wakatime/30.2.1"
+
+    result = WakatimeService.parse_user_agent(user_agent, category: "ai coding")
+
+    assert_equal "windows", result[:os]
+    assert_equal "copilot-cli", result[:editor]
+    assert_equal "gpt/5.3-codex", result[:ai_model]
+  end
+
+  def test_parse_user_agent_uses_the_first_ai_editor_after_the_model
+    vscode = WakatimeService.parse_user_agent(
+      "wakatime/v2.22.2 (darwin-arm64) go1.26.5 gpt/5.6 vscode-wakatime/unknown Zed/1.11.3 Zed-hackatime/0.3.1",
+      category: "ai coding"
+    )
+    opencode = WakatimeService.parse_user_agent(
+      "wakatime/v2.22.2 (darwin-arm64) go1.26.5 fable/5 opencode-cli/local Zed/1.11.3 Zed-hackatime/0.3.1",
+      category: "ai coding"
+    )
+
+    assert_equal "vscode", vscode[:editor]
+    assert_equal "gpt/5.6", vscode[:ai_model]
+    assert_equal "opencode-cli", opencode[:editor]
+    assert_equal "fable/5", opencode[:ai_model]
+  end
+
+  def test_parse_user_agent_skips_ai_agent_prefix_without_a_model
+    opencode = WakatimeService.parse_user_agent(
+      "wakatime/v2.22.2 (darwin-arm64) go1.26.5 opencode-cli/local Zed/1.11.3 Zed-hackatime/0.3.1",
+      category: "ai coding"
+    )
+    amp = WakatimeService.parse_user_agent(
+      "wakatime/v2.22.2 (darwin-arm64) go1.26.5 amp/unknown Zed/1.11.3 Zed-hackatime/0.3.1",
+      category: "ai coding"
+    )
+
+    assert_equal "zed", opencode[:editor]
+    assert_nil opencode[:ai_model]
+    assert_equal "zed", amp[:editor]
+    assert_nil amp[:ai_model]
+  end
+
+  def test_parse_user_agent_recognizes_dot_named_wakatime_plugins
+    result = WakatimeService.parse_user_agent(
+      "wakatime/v2.22.2 (linux-x86_64) go1.26.5 neovim/0.12 wakatime.nvim/12.0.0",
+      category: "ai coding"
+    )
+
+    assert_equal "neovim", result[:editor]
+    assert_nil result[:ai_model]
+  end
+
+  def test_parse_user_agent_ignores_parenthesized_plugin_metadata
+    result = WakatimeService.parse_user_agent(
+      "wakatime/v2.21.4 (linux-x86_64) go1.26.4 VSCodium/1.121.0 (Continue/2.0.0)",
+      category: "ai coding"
+    )
+
+    assert_equal "vscodium", result[:editor]
+    assert_nil result[:ai_model]
+  end
+
+  def test_parse_user_agent_does_not_treat_ai_agent_products_as_models
+    user_agents = {
+      "wakatime/v2.22.0 (windows-x86_64) go1.26.5 antigravity-desktop/unknown vscode/1.128.0 vscode-wakatime/30.2.1" => "vscode",
+      "wakatime/v2.21.4 (linux-x86_64) go1.26.4 github-copilot/0.55.0 VSCodium/1.121.0 vscode-wakatime/30.2.1" => "vscodium",
+      "wakatime/v2.14.7 (darwin-arm64) go1.26.3 ClaudeCode/2.1.197 cursor/1.105.1 vscode-wakatime/30.2.1" => "cursor",
+      "wakatime/v2.22.2 (linux-x86_64) go1.26.5 qwen-code-cli/0.17.0 zed/1.11.3 zed-hackatime/0.3.1" => "zed",
+      "wakatime/v2.16.1 (linux-x86_64) go1.26.4 OpenCode/1.17.9 opencode-cli/1.17.9 opencode-wakatime/1.3.8" => "opencode"
+    }
+
+    user_agents.each do |user_agent, editor|
+      result = WakatimeService.parse_user_agent(user_agent, category: "ai coding")
+      assert_equal editor, result[:editor]
+      assert_nil result[:ai_model]
+    end
+  end
+
+  def test_parse_user_agent_keeps_ai_agent_as_editor_when_a_model_precedes_it
+    result = WakatimeService.parse_user_agent(
+      "wakatime/v2.22.2 (linux-x86_64) go1.26.5 gpt/5.6 antigravity-cli/unknown vscode/1.128.0 vscode-wakatime/30.2.1",
+      category: "ai coding"
+    )
+
+    assert_equal "antigravity-cli", result[:editor]
+    assert_equal "gpt/5.6", result[:ai_model]
+  end
+
+  def test_parse_user_agent_does_not_treat_a_leading_plugin_as_a_model
+    result = WakatimeService.parse_user_agent(
+      "wakatime/v2.22.2 (darwin-arm64) go1.26.5 vscode-wakatime/unknown Codex/26.609.30741 macos-wakatime/5.28.4",
+      category: "ai coding"
+    )
+
+    assert_equal "vscode", result[:editor]
+    assert_nil result[:ai_model]
+  end
+
+  def test_parse_user_agent_handles_future_model_names_without_an_allowlist
+    user_agent = "wakatime/v2.21.4 (linux-6.17.0-x86_64) go1.26.4 mythos/5-high opencode-cli/1.4.4 vscode/1.128.0"
+
+    result = WakatimeService.parse_user_agent(user_agent, category: "ai coding")
+
+    assert_equal "opencode-cli", result[:editor]
+    assert_equal "mythos/5-high", result[:ai_model]
+  end
+
+  def test_parse_user_agent_does_not_treat_a_normal_editor_as_an_ai_model
+    user_agent = "wakatime/v2.21.4 (darwin-25.5.0-arm64) go1.26.4 vscode/1.128.0 vscode-wakatime/30.2.1"
+
+    result = WakatimeService.parse_user_agent(user_agent, category: "ai coding")
+
+    assert_equal "vscode", result[:editor]
+    assert_nil result[:ai_model]
+  end
+
+  def test_parse_user_agent_normalizes_selected_wakatime_plugin_to_its_editor
+    user_agent = "wakatime/v2.21.4 (linux-x86_64) go1.26.4 gpt/5.5-xhigh vscode-wakatime/unknown vscode/1.124.0"
+
+    result = WakatimeService.parse_user_agent(user_agent, category: "ai coding")
+
+    assert_equal "vscode", result[:editor]
+    assert_equal "gpt/5.5-xhigh", result[:ai_model]
+  end
+
+  def test_parse_user_agent_recognizes_claude_model_before_claude_code_plugin
+    user_agent = "wakatime/v2.21.4 (linux-x86_64) go1.26.4 claude/3.5 claude-code-wakatime/3.1.6"
+
+    result = WakatimeService.parse_user_agent(user_agent, category: "ai coding")
+
+    assert_equal "claude-code", result[:editor]
+    assert_equal "claude/3.5", result[:ai_model]
+  end
+
+  def test_parse_user_agent_recognizes_model_names_that_collide_with_editors
+    gemini_model = WakatimeService.parse_user_agent(
+      "wakatime/v2.22.2 (linux-x86_64) go1.26.5 gemini/3.5-flash-high antigravity-ide/1.14.2 antigravityide/1.14.2 vscode-wakatime/30.2.1",
+      category: "ai coding"
+    )
+    codex_model = WakatimeService.parse_user_agent(
+      "wakatime/v2.22.2 (darwin-arm64) go1.26.5 codex/mini-latest codex-cli/0.20.0 terminal/1.0.0",
+      category: "ai coding"
+    )
+
+    assert_equal "antigravity-ide", gemini_model[:editor]
+    assert_equal "gemini/3.5-flash-high", gemini_model[:ai_model]
+    assert_equal "codex-cli", codex_model[:editor]
+    assert_equal "codex/mini-latest", codex_model[:ai_model]
+  end
+
+  def test_parse_user_agent_keeps_colliding_editor_names_when_the_plugin_matches
+    codex = WakatimeService.parse_user_agent(
+      "wakatime/v2.22.2 (darwin-arm64) go1.26.5 codex/1.0.0 codex-wakatime/1.3.1",
+      category: "ai coding"
+    )
+    gemini = WakatimeService.parse_user_agent(
+      "wakatime/v2.22.2 (linux-x86_64) go1.26.5 gemini/1.0.0 gemini-wakatime/1.0.0",
+      category: "ai coding"
+    )
+
+    assert_equal "codex", codex[:editor]
+    assert_nil codex[:ai_model]
+    assert_equal "gemini", gemini[:editor]
+    assert_nil gemini[:ai_model]
+  end
+
+  def test_parse_user_agent_handles_official_direct_plugin_families
+    cases = {
+      "(Windows) vscode/1.90.0 vscode-wakatime/30.2.1" => [ "windows", "vscode" ],
+      "unity-wakatime" => [ "", "unity" ],
+      "adobexd-wakatime/3.0.0" => [ "", "adobexd" ],
+      "Roblox Studio/0.700.0 roblox-studio-wakatime/1.0.0" => [ "", "roblox-studio" ],
+      "linux_x86-64 betterdiscord/1.12.0 discord-wakatime/1.0.0" => [ "linux", "betterdiscord" ],
+      "Processing processing-wakatime/1.0.0" => [ "", "processing" ]
+    }
+
+    cases.each do |user_agent, (os, editor)|
+      result = WakatimeService.parse_user_agent(user_agent)
+      assert_equal os, result[:os], user_agent
+      assert_equal editor, result[:editor], user_agent
+      assert_nil result[:ai_model], user_agent
+      assert_nil result[:err], user_agent
+    end
+  end
+
+  def test_parse_user_agent_handles_direct_ai_transcript_chains
+    model = WakatimeService.parse_user_agent(
+      "opus/4-8 claude-code/2.1.202",
+      category: "ai coding"
+    )
+    source = WakatimeService.parse_user_agent(
+      "Codex zsh/5.9 terminal-wakatime/1.0.0",
+      category: "ai coding"
+    )
+
+    assert_equal "claude-code", model[:editor]
+    assert_equal "opus/4-8", model[:ai_model]
+    assert_equal "zsh", source[:editor]
+    assert_nil source[:ai_model]
+  end
+
+  def test_parse_user_agent_covers_every_current_ai_parser_user_agent_family
+    cases = {
+      "claude" => [ "opus/4-8 claude-code/2.1.202", "claude-code", "opus/4-8" ],
+      "codex" => [ "gpt/5.4-codex codex-cli/0.142.0", "codex-cli", "gpt/5.4-codex" ],
+      "amp" => [ "Amp/0.1.0 vscode/1.90 vscode-wakatime/30.2.1", "vscode", nil ],
+      "continue" => [ "codestral/25.01 vscode/1.90 vscode-wakatime/30.2.1", "vscode", "codestral/25.01" ],
+      "cody" => [ "claude/3.7 vscode/1.90 vscode-wakatime/30.2.1", "vscode", "claude/3.7" ],
+      "roo" => [ "vscode/1.90 vscode-wakatime/30.2.1", "vscode", nil ],
+      "opencode" => [ "deepseek/3 opencode-cli/1.17.9 vscode/1.90", "opencode-cli", "deepseek/3" ],
+      "copilot" => [ "github-copilot/0.55.0 vscode/1.90 vscode-wakatime/30.2.1", "vscode", nil ],
+      "cursor" => [ "claude/4 Cursor/1.125.0 vscode-wakatime/30.2.1", "cursor", "claude/4" ],
+      "windsurf" => [ "swe/1 windsurf/1.107.0 vscode-wakatime/30.2.1", "windsurf", "swe/1" ],
+      "qoder" => [ "qoder/1.13.0 vscode-wakatime/30.2.1", "qoder", nil ],
+      "kiro" => [ "kiro/1.107.1 vscode-wakatime/30.2.1", "kiro", nil ],
+      "cline" => [ "vscode/1.90 vscode-wakatime/30.2.1", "vscode", nil ],
+      "gemini" => [ "gemini/3.1-pro-high vscode/1.90 vscode-wakatime/30.2.1", "vscode", "gemini/3.1-pro-high" ],
+      "qwen" => [ "qwen/3 qwen-code-cli/0.17.0 zed/1.11.3", "qwen-code-cli", "qwen/3" ],
+      "pi" => [ "gpt/5.6 zsh/5.9 terminal-wakatime/1.1.5", "zsh", "gpt/5.6" ],
+      "goose" => [ "llama/4 neovim/0.12 wakatime.nvim/12.0.0", "neovim", "llama/4" ]
+    }
+
+    cases.each do |parser, (product_chain, editor, ai_model)|
+      result = WakatimeService.parse_user_agent(
+        "wakatime/v2.22.2 (linux-x86_64) go1.26.5 #{product_chain}",
+        category: "ai coding"
+      )
+
+      assert_equal editor, result[:editor], parser
+      if ai_model
+        assert_equal ai_model, result[:ai_model], parser
+      else
+        assert_nil result[:ai_model], parser
+      end
+    end
+  end
+
+  def test_parse_user_agent_preserves_a_standalone_cli_product
+    result = WakatimeService.parse_user_agent("wakatime-cli/1.2.3")
+
+    assert_equal "wakatime-cli", result[:editor]
+    assert_nil result[:err]
   end
 
   def test_parse_user_agent_with_Firefox
@@ -71,10 +335,54 @@ class WakatimeServiceTest < Minitest::Test
     assert_nil result[:error]
   end
 
+  def test_parse_user_agent_uses_plugin_fallback_and_skips_middleware
+    emacs = WakatimeService.parse_user_agent(
+      "wakatime/13.0.4 (Linux-5.4.64-x86_64-with-glibc2.2.5) Python3.7.6.final.0 emacs-wakatime/1.0.2"
+    )
+    helix = WakatimeService.parse_user_agent(
+      "wakatime/1.139.1 (linux-6.18.8-unknown) go1.25.5 helix/25.07.1 (74075bb5) wakatime-ls/0.2.2 helix-wakatime/0.2.2"
+    )
+
+    assert_equal "linux", emacs[:os]
+    assert_equal "emacs", emacs[:editor]
+    assert_equal "helix", helix[:editor]
+  end
+
+  def test_parse_user_agent_handles_wsl_and_browser_extension_user_agents
+    wsl = WakatimeService.parse_user_agent(
+      "wakatime/v1.106.1 (linux-5.15.167.4-microsoft-standard-WSL2-unknown) go1.23.3 cursor/1.93.1 vscode-wakatime/24.9.2"
+    )
+    edge = WakatimeService.parse_user_agent(
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 Edg/116.0.1938.62 win_x86-64 edge-wakatime/3.0.18"
+    )
+
+    assert_equal "wsl", wsl[:os]
+    assert_equal "cursor", wsl[:editor]
+    assert_equal "windows", edge[:os]
+    assert_equal "edge", edge[:editor]
+  end
+
+  def test_parse_user_agent_does_not_require_a_known_editor_for_two_product_chain
+    result = WakatimeService.parse_user_agent(
+      "wakatime/v2.21.4 (linux-x86_64) go1.26.4 future-editor/1.0.0 vscode-wakatime/30.2.1",
+      category: "ai coding"
+    )
+
+    assert_equal "future-editor", result[:editor]
+    assert_nil result[:ai_model]
+  end
+
   def test_parse_user_agent_with_invalid_user_agent
     user_agent = "invalid-user-agent"
     result = WakatimeService.parse_user_agent(user_agent)
     assert_equal "", result[:os]
+    assert_equal "", result[:editor]
+    assert_equal "failed to parse user agent string", result[:err]
+  end
+
+  def test_parse_user_agent_rejects_an_unstructured_spaced_product
+    result = WakatimeService.parse_user_agent("codex agent/1.0")
+
     assert_equal "", result[:editor]
     assert_equal "failed to parse user agent string", result[:err]
   end

--- a/test/lib/wakatime_service_test.rb
+++ b/test/lib/wakatime_service_test.rb
@@ -337,6 +337,18 @@ class WakatimeServiceTest < Minitest::Test
     assert_nil result[:err]
   end
 
+  def test_parse_user_agent_skips_parenthesized_metadata_before_the_ai_model
+    result = WakatimeService.parse_user_agent(
+      "wakatime/1.0 (linux) (extra) opus/4-8 claude-code/2.1",
+      category: "ai coding"
+    )
+
+    assert_equal "linux", result[:os]
+    assert_equal "claude-code", result[:editor]
+    assert_equal "opus/4-8", result[:ai_model]
+    assert_nil result[:err]
+  end
+
   def test_parse_user_agent_with_Firefox
     user_agent = "Firefox/139.0 linux_x86-64 firefox-wakatime/4.1.0"
     result = WakatimeService.parse_user_agent(user_agent)

--- a/test/lib/wakatime_service_test.rb
+++ b/test/lib/wakatime_service_test.rb
@@ -25,6 +25,16 @@ class WakatimeServiceTest < Minitest::Test
     assert_nil result[:ai_model]
   end
 
+  def test_parse_user_agent_without_products_after_the_platform
+    result = WakatimeService.parse_user_agent(
+      "wakatime/v1.86.0 (windows-10.0.22631-x86_64)"
+    )
+
+    assert_equal "windows", result[:os]
+    assert_equal "", result[:editor]
+    assert_nil result[:err]
+  end
+
   def test_parse_user_agent_with_GitHub_Desktop
     user_agent = "wakatime/v1.0.0 (darwin-arm64) go1.0.0 github-desktop/1.0.0"
     result = WakatimeService.parse_user_agent(user_agent)

--- a/test/services/heartbeat_import_service_test.rb
+++ b/test/services/heartbeat_import_service_test.rb
@@ -90,4 +90,36 @@ class HeartbeatImportServiceTest < ActiveSupport::TestCase
       Heartbeat.skip_callback(:validate, :before, validation)
     end
   end
+
+  test "re-importing placeholders is idempotent after database context changes" do
+    user = User.create!(timezone: "UTC")
+    file_content = {
+      heartbeats: [
+        {
+          branch: "<<LAST_BRANCH>>",
+          entity: "notes",
+          language: "<<LAST_LANGUAGE>>",
+          project: "api",
+          time: 1_700_000_000.0,
+          type: "file"
+        },
+        {
+          branch: "main",
+          entity: "b.rb",
+          language: "Ruby",
+          project: "api",
+          time: 1_700_000_001.0,
+          type: "file"
+        }
+      ]
+    }.to_json
+
+    first = HeartbeatImportService.import_from_file(file_content, user)
+    second = HeartbeatImportService.import_from_file(file_content, user)
+
+    assert_equal 2, first[:imported_count]
+    assert_equal 0, second[:imported_count]
+    assert_equal 2, second[:skipped_count]
+    assert_equal 2, user.heartbeats.count
+  end
 end

--- a/test/services/heartbeat_import_service_test.rb
+++ b/test/services/heartbeat_import_service_test.rb
@@ -69,4 +69,25 @@ class HeartbeatImportServiceTest < ActiveSupport::TestCase
     assert_equal "skyfall-pc", heartbeat.machine
     assert_equal "wakatime/v1.102.1", heartbeat.user_agent
   end
+
+  test "normalizes and validates each imported heartbeat once" do
+    user = User.create!(timezone: "UTC")
+    validation_count = 0
+    validation = lambda do |_heartbeat|
+      validation_count += 1
+    end
+    Heartbeat.set_callback(:validate, :before, validation)
+
+    begin
+      result = HeartbeatImportService.import_from_file(
+        { heartbeats: [ { entity: "/tmp/test.rb", time: 1_700_000_000.0, type: "file" } ] }.to_json,
+        user
+      )
+
+      assert result[:success]
+      assert_equal 1, validation_count
+    ensure
+      Heartbeat.skip_callback(:validate, :before, validation)
+    end
+  end
 end

--- a/test/services/heartbeat_ingest_test.rb
+++ b/test/services/heartbeat_ingest_test.rb
@@ -589,6 +589,26 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     assert_equal "<<LAST_PROJECT>>", heartbeats.last.project
   end
 
+  test "placeholder resolution fills missing in-batch context from database history" do
+    user = User.create!(timezone: "UTC")
+    now = Time.current.to_f
+    user.heartbeats.create!(
+      entity: "historical.rb", project: "api", branch: "main", language: "Ruby",
+      category: "coding", source_type: :direct_entry, time: now - 10, type: "file"
+    )
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :direct,
+      heartbeats: [
+        { entity: "first.py", project: "api", language: "Python", time: now - 1, type: "file" },
+        { entity: "second.py", project: "api", branch: "<<LAST_BRANCH>>", language: "Python", time: now, type: "file" }
+      ]
+    )
+
+    assert_equal [ nil, "main" ], user.heartbeats.where(entity: [ "first.py", "second.py" ]).order(:time).pluck(:branch)
+  end
+
   test "heartbeat_unique_by targets the composite index once time_epoch exists" do
     ingest = HeartbeatIngest.new(user: User.new, mode: :direct, heartbeats: [])
 

--- a/test/services/heartbeat_ingest_test.rb
+++ b/test/services/heartbeat_ingest_test.rb
@@ -58,6 +58,79 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     assert_equal "direct_entry", heartbeat.source_type
   end
 
+  test "direct heartbeat ingest applies blank defaults and falls back to body metadata" do
+    user = User.create!(timezone: "UTC")
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :direct,
+      heartbeats: [ {
+        category: "",
+        editor: "zed",
+        entity: "src/main.rb",
+        machine: "body-machine",
+        operating_system: "linux",
+        plugin: "zed/1.0.0",
+        time: Time.current.to_f,
+        type: "file",
+        user_agent: ""
+      } ]
+    )
+
+    heartbeat = user.heartbeats.sole
+    assert_equal "coding", heartbeat.category
+    assert_equal "zed/1.0.0", heartbeat.user_agent
+    assert_equal "zed", heartbeat.editor
+    assert_equal "linux", heartbeat.operating_system
+    assert_equal "body-machine", heartbeat.machine
+  end
+
+  test "direct heartbeat ingest classifies uncategorized browser heartbeats as browsing" do
+    user = User.create!(timezone: "UTC")
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :direct,
+      heartbeats: [ { entity: "example.com", time: Time.current.to_f, type: "domain" } ]
+    )
+
+    assert_equal "browsing", user.heartbeats.sole.category
+  end
+
+  test "direct heartbeat ingest uses the HTTP user agent when the body omits it" do
+    user = User.create!(timezone: "UTC")
+    user_agent = "wakatime/v1.0.0 (linux-x86_64) go1.0.0 zed/1.0.0"
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :direct,
+      heartbeats: [ { entity: "src/main.rb", time: Time.current.to_f, type: "file" } ],
+      request_context: { user_agent: user_agent }
+    )
+
+    heartbeat = user.heartbeats.sole
+    assert_equal user_agent, heartbeat.user_agent
+    assert_equal "zed", heartbeat.editor
+  end
+
+  test "direct heartbeat ingest prefers request machine over body machine" do
+    user = User.create!(timezone: "UTC")
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :direct,
+      heartbeats: [ {
+        entity: "src/main.rb",
+        machine: "body-machine",
+        time: Time.current.to_f,
+        type: "file"
+      } ],
+      request_context: { machine: "header-machine" }
+    )
+
+    assert_equal "header-machine", user.heartbeats.sole.machine
+  end
+
   test "direct heartbeat ingest reuses a JA4 record across requests" do
     user = User.create!(timezone: "UTC")
     ja4 = "t13d1516h2_8daaf6152771_02713d6af862"
@@ -118,6 +191,159 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     assert_no_enqueued_jobs only: DashboardRollupRefreshJob
   end
 
+  test "direct heartbeat ingest inserts distinct bulk items in one statement and preserves item order" do
+    user = User.create!(timezone: "UTC")
+    now = Time.current.to_f
+    sql = []
+    subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+      statement = payload[:sql]
+      sql << statement if statement.include?('"heartbeats"') && !payload[:cached]
+    end
+
+    result = ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") do
+      HeartbeatIngest.call(
+        user: user,
+        mode: :direct,
+        heartbeats: [
+          { entity: "src/first.rb", project: "one", time: now - 1, type: "file" },
+          { branch: "main", entity: "src/second.py", project: "two", time: now, type: "file" }
+        ]
+      )
+    end
+
+    assert_equal 2, result.persisted_count
+    assert_equal 0, result.duplicate_count
+    assert_equal [ "src/first.rb", "src/second.py" ], result.items.map { |item| item.heartbeat.entity }
+    insert = sql.select { |statement| statement.start_with?('INSERT INTO "heartbeats"') }.sole
+    assert_includes insert, "ON CONFLICT"
+    assert_includes insert, "DO NOTHING"
+    assert_equal 1, sql.count { |statement| statement.start_with?("SELECT") && statement.include?("fields_hash") }
+  end
+
+  test "direct heartbeat ingest runs model validations before bulk insertion" do
+    user = User.create!(timezone: "UTC")
+    validation = lambda do |heartbeat|
+      heartbeat.errors.add(:entity, "is rejected by a model validation") if heartbeat.entity == "rejected.rb"
+    end
+    Heartbeat.set_callback(:validate, :before, validation)
+
+    begin
+      assert_no_difference("user.heartbeats.count") do
+        result = HeartbeatIngest.call(
+          user:,
+          mode: :direct,
+          heartbeats: [ { entity: "rejected.rb", time: Time.current.to_f, type: "file" } ]
+        )
+
+        assert_equal 1, result.failed_count
+        assert_instance_of ActiveRecord::RecordInvalid, result.items.sole.error
+        assert_includes result.items.sole.error.message, "Entity is rejected by a model validation"
+      end
+    ensure
+      Heartbeat.skip_callback(:validate, :before, validation)
+    end
+  end
+
+  test "import heartbeat ingest runs model validations before bulk insertion" do
+    user = User.create!(timezone: "UTC")
+    validation = lambda do |heartbeat|
+      heartbeat.errors.add(:entity, "is rejected by a model validation") if heartbeat.entity == "rejected.rb"
+    end
+    Heartbeat.set_callback(:validate, :before, validation)
+
+    begin
+      assert_no_difference("user.heartbeats.count") do
+        result = HeartbeatIngest.call(
+          user:,
+          mode: :import,
+          heartbeats: [ { entity: "rejected.rb", time: Time.current.to_f, type: "file" } ]
+        )
+
+        assert_equal 1, result.failed_count
+        assert_equal "ActiveRecord::RecordInvalid", result.errors.sole[:type]
+        assert_includes result.errors.sole[:error], "Entity is rejected by a model validation"
+      end
+    ensure
+      Heartbeat.skip_callback(:validate, :before, validation)
+    end
+  end
+
+  test "a validation failure does not seed placeholder state for later bulk items" do
+    user = User.create!(timezone: "UTC")
+    now = Time.current.to_f
+    validation = lambda do |heartbeat|
+      heartbeat.errors.add(:entity, "is rejected by a model validation") if heartbeat.entity == "rejected.py"
+    end
+    Heartbeat.set_callback(:validate, :before, validation)
+
+    begin
+      result = HeartbeatIngest.call(
+        user:,
+        mode: :direct,
+        heartbeats: [
+          { entity: "rejected.py", language: "Python", project: "demo", time: now - 1, type: "file" },
+          { entity: "accepted", language: "<<LAST_LANGUAGE>>", project: "demo", time: now, type: "file" }
+        ]
+      )
+
+      assert_equal 1, result.persisted_count
+      assert_equal 1, result.failed_count
+      assert_nil user.heartbeats.sole.language
+    ensure
+      Heartbeat.skip_callback(:validate, :before, validation)
+    end
+  end
+
+  test "direct heartbeat ingest refetches a concurrent winner after an insert conflict" do
+    user = User.create!(timezone: "UTC")
+    payload = { entity: "src/raced.rb", time: Time.current.to_f, type: "file" }
+    winner = nil
+    no_inserted_rows = ActiveRecord::Result.new([], [])
+    original_insert_all = Heartbeat.method(:insert_all)
+
+    Heartbeat.define_singleton_method(:insert_all) do |records, **|
+      winner = Heartbeat.create!(records.sole)
+      no_inserted_rows
+    end
+
+    begin
+      result = HeartbeatIngest.call(user:, mode: :direct, heartbeats: [ payload ])
+
+      assert_equal 0, result.persisted_count
+      assert_equal 1, result.duplicate_count
+      assert_equal 0, result.failed_count
+      assert_equal winner.id, result.items.sole.heartbeat.id
+    ensure
+      Heartbeat.define_singleton_method(:insert_all, original_insert_all)
+    end
+
+    assert_equal 1, user.heartbeats.count
+  end
+
+  test "direct heartbeat ingest deduplicates repeated items within one bulk request" do
+    user = User.create!(timezone: "UTC")
+    payload = {
+      entity: "src/main.rb",
+      project: "hackatime",
+      time: Time.current.to_f,
+      type: "file"
+    }
+
+    assert_difference("user.heartbeats.count", 1) do
+      result = HeartbeatIngest.call(
+        user: user,
+        mode: :direct,
+        heartbeats: [ payload, payload.dup ]
+      )
+
+      assert_equal 2, result.total_count
+      assert_equal 1, result.persisted_count
+      assert_equal 1, result.duplicate_count
+      assert_equal 0, result.failed_count
+      assert_equal 1, result.items.map { |item| item.heartbeat.id }.uniq.length
+    end
+  end
+
   test "direct heartbeat ingest resolves last language within the batch" do
     user = User.create!(timezone: "UTC")
     now = Time.current.to_f
@@ -163,6 +389,49 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     assert_in_delta sane_time, user.heartbeats.sole.time, 1.0
   end
 
+  test "direct AI heartbeat ingest stores the editor instead of the model" do
+    user = User.create!(timezone: "UTC")
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :direct,
+      heartbeats: [ {
+        category: "ai coding",
+        entity: "Claude session",
+        time: Time.current.to_f,
+        type: "app",
+        user_agent: "wakatime/v2.21.4 (darwin-25.5.0-arm64) go1.26.4 opus/4-8 claude-code/2.1.202"
+      } ]
+    )
+
+    heartbeat = user.heartbeats.sole
+    assert_equal "claude-code", heartbeat.editor
+    assert_equal "opus/4-8", heartbeat.ai_model
+    assert_equal "macos", heartbeat.operating_system
+  end
+
+  test "direct AI heartbeat ingest does not deduplicate distinct telemetry at the same timestamp" do
+    user = User.create!(timezone: "UTC")
+    timestamp = Time.current.to_f
+    base = {
+      ai_session: "session-123",
+      category: "ai coding",
+      entity: "Claude session",
+      time: timestamp,
+      type: "app",
+      user_agent: "wakatime/v2.21.4 (darwin-arm64) go1.26.4 opus/4-8 claude-code/2.1.202"
+    }
+
+    result = HeartbeatIngest.call(
+      user: user,
+      mode: :direct,
+      heartbeats: [ base.merge(ai_output_tokens: 100), base.merge(ai_output_tokens: 200) ]
+    )
+
+    assert_equal 2, result.persisted_count
+    assert_equal [ 100, 200 ], user.heartbeats.order(:ai_output_tokens).pluck(:ai_output_tokens)
+  end
+
   test "import heartbeat ingest normalizes nanosecond-scaled epoch times" do
     user = User.create!(timezone: "UTC")
     sane_time = 1_700_000_000.0
@@ -176,14 +445,136 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     assert_in_delta sane_time, user.heartbeats.sole.time, 1.0
   end
 
-  test "epoch normalization leaves sane and unrepairable values untouched" do
+  test "import heartbeat ingest applies blank defaults and sanitizes project names" do
+    user = User.create!(timezone: "UTC")
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :import,
+      heartbeats: [ {
+        category: "",
+        entity: "/tmp/test.rb",
+        project: "  hacka\u0000time\n",
+        time: 1_700_000_000.0,
+        type: "file"
+      } ]
+    )
+
+    heartbeat = user.heartbeats.sole
+    assert_equal "coding", heartbeat.category
+    assert_equal "hackatime", heartbeat.project
+  end
+
+  test "import heartbeat ingest preserves AI telemetry" do
+    user = User.create!(timezone: "UTC")
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :import,
+      heartbeats: [ {
+        ai_input_tokens: 1_000,
+        ai_line_changes: 12,
+        ai_output_tokens: 250,
+        ai_prompt_length: 80,
+        ai_session: "session-123",
+        ai_subscription_plan: "pro",
+        category: "ai coding",
+        editor: "mythos",
+        entity: "/tmp/test.rb",
+        human_line_changes: 4,
+        time: 1_700_000_000.0,
+        type: "file",
+        user_agent: "wakatime/v2.21.4 (linux-x86_64) go1.26.4 mythos/5-high opencode-cli/1.4.4"
+      } ]
+    )
+
+    heartbeat = user.heartbeats.sole
+    assert_equal "mythos/5-high", heartbeat.ai_model
+    assert_equal "opencode-cli", heartbeat.editor
+    assert_equal "session-123", heartbeat.ai_session
+    assert_equal "pro", heartbeat.ai_subscription_plan
+    assert_equal 1_000, heartbeat.ai_input_tokens
+    assert_equal 250, heartbeat.ai_output_tokens
+    assert_equal 80, heartbeat.ai_prompt_length
+    assert_equal 12, heartbeat.ai_line_changes
+    assert_equal 4, heartbeat.human_line_changes
+  end
+
+  test "direct heartbeat ingest does not queue repo mapping for the last-project sentinel" do
+    user = User.create!(timezone: "UTC")
+
+    assert_no_enqueued_jobs only: AttemptProjectRepoMappingJob do
+      HeartbeatIngest.call(
+        user: user,
+        mode: :direct,
+        heartbeats: [ {
+          entity: "src/main.rb",
+          project: "<<LAST_PROJECT>>",
+          time: Time.current.to_f,
+          type: "file"
+        } ]
+      )
+    end
+  end
+
+  test "epoch normalization preserves sane values and rejects unrepairable values" do
     ingest = HeartbeatIngest.new(user: User.new, mode: :direct, heartbeats: [])
 
     sane = Time.current.to_f
     assert_equal sane, ingest.send(:normalize_epoch_time, sane)
-    # literal-year garbage is not scaled data; passes through (quarantined DB-side later)
-    assert_equal 2026.0, ingest.send(:normalize_epoch_time, 2026)
-    assert_equal(-9_999_999.0, ingest.send(:normalize_epoch_time, -9_999_999))
+    assert_raises(HeartbeatIngest::InvalidHeartbeatTime) { ingest.send(:normalize_epoch_time, 2026) }
+    assert_raises(HeartbeatIngest::InvalidHeartbeatTime) { ingest.send(:normalize_epoch_time, -9_999_999) }
+    assert_raises(HeartbeatIngest::InvalidHeartbeatTime) { ingest.send(:normalize_epoch_time, "not-a-time") }
+    assert_raises(HeartbeatIngest::InvalidHeartbeatTime) { ingest.send(:normalize_epoch_time, Float::NAN) }
+  end
+
+  test "direct heartbeat ingest reports invalid timestamps without persisting them" do
+    user = User.create!(timezone: "UTC")
+
+    assert_no_difference("user.heartbeats.count") do
+      result = HeartbeatIngest.call(
+        user: user,
+        mode: :direct,
+        heartbeats: [ { entity: "src/main.rb", time: 2026, type: "file" } ]
+      )
+
+      assert_equal 1, result.failed_count
+      assert_instance_of HeartbeatIngest::InvalidHeartbeatTime, result.items.sole.error
+    end
+  end
+
+  test "direct heartbeat ingest rejects timestamps more than an hour in the future" do
+    user = User.create!(timezone: "UTC")
+
+    result = HeartbeatIngest.call(
+      user: user,
+      mode: :direct,
+      heartbeats: [ { entity: "src/main.rb", time: 2.hours.from_now.to_f, type: "file" } ]
+    )
+
+    assert_equal 1, result.failed_count
+    assert_instance_of HeartbeatIngest::InvalidHeartbeatTime, result.items.sole.error
+  end
+
+  test "direct placeholder resolution is scoped to the project and preserves last project" do
+    user = User.create!(timezone: "UTC")
+    now = Time.current.to_f
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :direct,
+      heartbeats: [
+        { entity: "a.rb", project: "a", branch: "main", language: "Ruby", time: now - 3, type: "file" },
+        { entity: "b.py", project: "b", branch: "trunk", language: "Python", time: now - 2, type: "file" },
+        { entity: "b-next.py", project: "b", branch: "<<LAST_BRANCH>>", language: "<<LAST_LANGUAGE>>", time: now - 1, type: "file" },
+        { entity: "last.py", project: "<<LAST_PROJECT>>", branch: "<<LAST_BRANCH>>", language: "<<LAST_LANGUAGE>>", time: now, type: "file" }
+      ]
+    )
+
+    heartbeats = user.heartbeats.order(:time).last(2)
+    assert_equal [ "Python", "Python" ], heartbeats.pluck(:language)
+    assert_equal [ "trunk", "trunk" ], heartbeats.pluck(:branch)
+    assert_equal "<<LAST_PROJECT>>", heartbeats.last.project
   end
 
   test "heartbeat_unique_by targets the composite index once time_epoch exists" do

--- a/test/services/heartbeat_ingest_test.rb
+++ b/test/services/heartbeat_ingest_test.rb
@@ -332,6 +332,47 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     assert_equal 1, user.heartbeats.count
   end
 
+  test "direct heartbeat ingest rebuilds partition attributes inside a schema retry" do
+    user = User.create!(timezone: "UTC")
+    time = Time.current.to_f
+    attrs = { user_id: user.id, entity: "src/main.rb", time:, type: "file", category: "coding", source_type: :direct_entry }
+    model_attributes = Heartbeat.new(attrs).attributes
+    fields_hash = Heartbeat.generate_fields_hash(model_attributes)
+    entry = { attrs:, model_attributes:, fields_hash: }
+    ingest = HeartbeatIngest.new(user:, mode: :direct, heartbeats: [], schedule_rollup_refresh: false)
+    attempts = []
+    include_time_epoch = false
+    original_column_names = Heartbeat.method(:column_names)
+    original_insert_all = Heartbeat.method(:insert_all)
+
+    Heartbeat.define_singleton_method(:column_names) do
+      columns = original_column_names.call
+      include_time_epoch ? columns + [ "time_epoch" ] : columns
+    end
+    Heartbeat.define_singleton_method(:insert_all) do |records, **|
+      attempts << records
+      raise ArgumentError, "stale schema" if attempts.one?
+
+      ActiveRecord::Result.new([ "fields_hash" ], [ [ fields_hash ] ])
+    end
+    ingest.define_singleton_method(:with_heartbeat_unique_by) do |&block|
+      block.call([ :fields_hash ])
+    rescue ArgumentError
+      include_time_epoch = true
+      block.call(%i[fields_hash time_epoch])
+    end
+
+    begin
+      ingest.send(:persist_direct_heartbeats, [ entry ])
+    ensure
+      Heartbeat.define_singleton_method(:column_names, original_column_names)
+      Heartbeat.define_singleton_method(:insert_all, original_insert_all)
+    end
+
+    assert_not attempts.first.sole.key?("time_epoch")
+    assert_equal time.floor, attempts.second.sole.fetch("time_epoch")
+  end
+
   test "direct heartbeat ingest deduplicates repeated items within one bulk request" do
     user = User.create!(timezone: "UTC")
     payload = {

--- a/test/services/heartbeat_ingest_test.rb
+++ b/test/services/heartbeat_ingest_test.rb
@@ -477,6 +477,73 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     assert_equal "hackatime", heartbeat.project
   end
 
+  test "import heartbeat ingest recognizes a pre-normalization fields hash" do
+    user = User.create!(timezone: "UTC")
+    raw = {
+      category: "",
+      entity: "/tmp/test.rb",
+      project: "  hackatime\n",
+      time: 1_700_000_000.0,
+      type: "file"
+    }
+    create_legacy_imported_heartbeat(
+      user,
+      category: raw[:category], entity: raw[:entity], language: "Ruby",
+      project: raw[:project], time: raw[:time], type: raw[:type]
+    )
+
+    assert_no_difference("user.heartbeats.count") do
+      result = HeartbeatIngest.call(user: user, mode: :import, heartbeats: [ raw ])
+
+      assert_equal 0, result.persisted_count
+      assert_equal 1, result.duplicate_count
+    end
+  end
+
+  test "import heartbeat ingest recognizes legacy hashes containing placeholders" do
+    user = User.create!(timezone: "UTC")
+    raw = {
+      branch: "<<LAST_BRANCH>>",
+      entity: "/tmp/test.rb",
+      language: "<<LAST_LANGUAGE>>",
+      project: "api",
+      time: 1_700_000_000.0,
+      type: "file"
+    }
+    create_legacy_imported_heartbeat(user, raw.merge(category: "coding"))
+
+    assert_no_difference("user.heartbeats.count") do
+      result = HeartbeatIngest.call(user: user, mode: :import, heartbeats: [ raw ])
+
+      assert_equal 0, result.persisted_count
+      assert_equal 1, result.duplicate_count
+    end
+  end
+
+  test "import heartbeat ingest recognizes legacy user agent normalization hashes" do
+    user = User.create!(timezone: "UTC")
+    user_agent = "wakatime/v1.0.0 (darwin-arm64) go1.0.0 vscode/1.90.0"
+    raw = {
+      category: "coding",
+      entity: "/tmp/test.rb",
+      project: "api",
+      time: 1_700_000_000.0,
+      type: "file",
+      user_agent:
+    }
+    create_legacy_imported_heartbeat(
+      user,
+      raw.merge(editor: "vscode", language: "Ruby", operating_system: "darwin")
+    )
+
+    assert_no_difference("user.heartbeats.count") do
+      result = HeartbeatIngest.call(user: user, mode: :import, heartbeats: [ raw ])
+
+      assert_equal 0, result.persisted_count
+      assert_equal 1, result.duplicate_count
+    end
+  end
+
   test "import heartbeat ingest preserves AI telemetry" do
     user = User.create!(timezone: "UTC")
 
@@ -708,6 +775,19 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
 
     heartbeat = user.heartbeats.order(:id).last
     assert_equal "wakapi_import", heartbeat.source_type
+  end
+
+  private
+
+  def create_legacy_imported_heartbeat(user, attributes)
+    legacy_attributes = Heartbeat.indexed_attributes.index_with { nil }.symbolize_keys.merge(
+      dependencies: [],
+      is_write: false,
+      user_id: user.id
+    ).merge(attributes)
+    heartbeat = user.heartbeats.create!(legacy_attributes.merge(source_type: :wakapi_import))
+    heartbeat.update_column(:fields_hash, Heartbeat.generate_fields_hash(legacy_attributes))
+    heartbeat
   end
 end
 

--- a/test/services/heartbeat_ingest_test.rb
+++ b/test/services/heartbeat_ingest_test.rb
@@ -97,6 +97,18 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     assert_equal "browsing", user.heartbeats.sole.category
   end
 
+  test "direct heartbeat ingest classifies a minimal heartbeat as coding" do
+    user = User.create!(timezone: "UTC")
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :direct,
+      heartbeats: [ { entity: "LICENSE", time: Time.current.to_f } ]
+    )
+
+    assert_equal "coding", user.heartbeats.sole.category
+  end
+
   test "direct heartbeat ingest uses the HTTP user agent when the body omits it" do
     user = User.create!(timezone: "UTC")
     user_agent = "wakatime/v1.0.0 (linux-x86_64) go1.0.0 zed/1.0.0"


### PR DESCRIPTION
> [!WARNING]
> This PR was authored with Fable and 5.6 Sol. It was reviewed by me though!

---

## Summary of the problem

The direct ingestion and Wakapi import paths disagreed on heartbeat normalization, user agent parsing and malformed bulk request behavior. AI model names could be stored as editors, AI transcript metadata was discarded and direct bulk requests used one insert per valid heartbeat.

## Describe your changes

- Add dedicated heartbeat columns for every supported AI telemetry field.
- Preserve AI telemetry during direct ingestion, Wakapi imports and heartbeat exports.
- Include populated AI telemetry in heartbeat deduplication hashes.
- Parse layered WakaTime user agents so editor products, operating systems and AI models are attributed separately.
- Preserve editors in runtime-less WakaTime user agents.
- Ignore parenthesized extension metadata when classifying model-prefixed user agents.
- Keep leading WakaTime plugin products out of `ai_model`.
- Recognize current Copilot, Antigravity, Claude Code, Qwen and OpenCode source prefixes without treating them as models.
- Disambiguate lowercase Claude, Codex and Gemini model products from matching standalone editor products.
- Accept explicit `ai_model` values during direct ingestion.
- Prefer explicit AI models over models derived from user agents.
- Follow wakatime-cli product order when a model prefixes an AI editor.
- Skip agent-only prefixes when a host editor follows them.
- Recognize new editor plugins by naming convention instead of an editor allowlist.
- Recognize dot-named `wakatime.nvim` user agent products.
- Normalize Copilot CLI and VS Code editor product variants.
- Parse direct official plugin values from VS Code Web, Unity, Roblox Studio, Fusion 360, Discord and similar clients.
- Normalize direct `-wakatime`, `_wakatime`, `-hackatime` and `_hackatime` products to their editor names.
- Keep explicit editor metadata when a user agent does not identify a reliable editor.
- Return the persisted heartbeat from successful single-heartbeat requests.
- Normalize epoch seconds and repair timestamps sent in milliseconds, microseconds or nanoseconds.
- Reject invalid direct heartbeat timestamps and timestamps too far in the future.
- Infer default categories from heartbeat type and language.
- Resolve `<<LAST_LANGUAGE>>` and `<<LAST_BRANCH>>` using project-scoped context.
- Preserve `<<LAST_PROJECT>>` as required for accurate elapsed time.
- Return a result for every bulk item while allowing valid items to persist beside malformed items.
- Deduplicate direct bulk heartbeats, prefetch existing hashes once and insert missing rows in one SQL statement.
- Run the normal Active Record validation chain before direct and imported bulk inserts.
- Update placeholder state only from heartbeat items that pass model validation.
- Refetch the concurrent winner when `ON CONFLICT DO NOTHING` skips a raced heartbeat.
- Preserve conflict handling across the legacy unique index and Timescale composite index.
- Sanitize project names and hash repository mapping cache keys.
- Filter AI session and prompt metadata from logs.
- Load archived project details from heartbeats instead of active-only dashboard rollups.
- Add regression coverage for direct ingestion, Wakapi import behavior, user agent parsing, archived project display, export parity and bulk SQL behavior.

## User agent source audit

- Reviewed all 90 repositories in the WakaTime GitHub organization as of July 22, 2026.
- Traced 70 plugin, collector, shared-client and compatibility repositories.
- Confirmed that the current Go CLI produces `wakatime/<version> (<platform>) <runtime> <plugin chain>`.
- Confirmed that the legacy Python CLI produces `wakatime/<version> (<platform>) Python<version> <plugin chain>`.
- Found 48 repositories containing a `--plugin` integration path that delegates the final envelope to a WakaTime CLI.
- Traced direct heartbeat producers for Adobe XD, Brackets, browsers, Camunda Modeler, Discord, Figma, Roblox Studio and Vencord.
- Traced the shared .NET metadata path used by Visual Studio, SSMS, Microsoft Office and MonoDevelop.
- Traced VS Code desktop editor-fork detection for Arduino, Azure Data Studio, Cursor, Kiro, Onivim, Qoder, SQL Ops, Trae and Windsurf.
- Traced the separate VS Code Web format that starts with a parenthesized platform and has no CLI envelope.
- Traced all 17 current AI parser implementations, including the Antigravity variants inside Gemini.
- Confirmed that model-aware parsers prepend a normalized model product before the source editor or existing host editor chain.
- Confirmed that Copilot does not currently include a model product, so Hackatime can recover the host or CLI editor but not `ai_model` from its user agent.
- Confirmed that current Pi emits the normalized model directly while a small legacy population used an ambiguous `Pi/<model>` product.

## Examples

- `opus/4-8 claude-code/2.1.202` now stores `ai_model: opus/4-8` and `editor: claude-code` instead of storing `opus` as the editor.
- `gemini/3.5-flash-high antigravity-ide/...` now stores `ai_model: gemini/3.5-flash-high` and `editor: antigravity-ide` instead of dropping the model.
- `codex/1.0 codex-wakatime/1.3.1` remains a normal `codex` editor chain and does not store a false model.
- `gpt/5.6 vscode-wakatime/unknown Zed/...` now stores `ai_model: gpt/5.6` and `editor: vscode` because the first product after the model identifies the AI editor.
- `fable/5 opencode-cli/local Zed/...` now stores `ai_model: fable/5` and `editor: opencode-cli` without requiring Hackatime to know the Fable model name in advance.
- `opencode-cli/local Zed/... Zed-hackatime/...` without a model prefix now stores `editor: zed` and leaves `ai_model` empty.
- `OpenCode/... opencode-cli/... opencode-wakatime/...` without a model prefix now stores `editor: opencode` and leaves `ai_model` empty.
- `github-copilot/... VSCodium/... vscode-wakatime/...` without a model prefix now stores `editor: vscodium` and leaves `ai_model` empty.
- `VSCodium/... (Continue/...)` now stores `editor: vscodium` without treating VSCodium as a model.
- `neovim/0.12 wakatime.nvim/12.0.0` now stores `editor: neovim` instead of treating `neovim` as an AI model.
- `wakatime/1.0 (linux-x86_64) vscode/1.90` now stores `editor: vscode` even though it has no Go or Python runtime token.
- `(Windows) vscode/1.90 vscode-wakatime/30.2.1` now stores `operating_system: windows` and `editor: vscode`.
- `unity-hackatime` now stores `editor: unity` instead of leaving the editor empty.
- `Roblox Studio/... roblox-studio-wakatime/...` now stores `editor: roblox-studio` despite the space in the leading product.
- A direct payload containing `ai_model: gpt/5.6` now preserves that model even when its user agent contains no model token.
- A successful single-heartbeat response now contains the persisted heartbeat ID and attributes.
- A timestamp such as `1784736000000` is repaired from milliseconds to epoch seconds before validation and persistence.
- A bulk request containing valid, malformed and duplicate items now returns one result per input while inserting all unique valid items with one SQL statement.

## Production impact audit

- Replayed 23,428,077 production heartbeats from 12,614 users between July 1 and July 23, 2026.
- Covered 175,471 distinct user, user agent, category, editor and operating system shapes without a parser exception.
- Reduced unresolved user agent rows from about 89,700 to 9,321 while leaving arbitrary UUID and custom strings rejected.
- Recovered Gemini models on 261,775 heartbeats from 1,140 users across 28 model variants.
- Recovered 66,462 `unity-hackatime` heartbeats from 149 users.
- Recovered 7,207 `unity-wakatime` heartbeats from 7 users.
- Normalized 18,840 plugin-only Roblox Studio heartbeats from 56 users.
- Recovered 5,886 malformed spaced Roblox Studio heartbeats across coding, building and manual testing categories.
- Recovered 680 spaced Fusion 360 heartbeats.
- Recovered direct plugin-only and VS Code Web shapes without using an editor allowlist.
- Separated 946,388 Opus heartbeats from `claude-code` editor attribution across 1,167 users.
- Separated 660,400 Sonnet heartbeats from `claude-code` editor attribution across 1,159 users.
- Separated 619,251 GPT heartbeats from `vscode` editor attribution across 1,393 users.
- Separated 470,743 Fable heartbeats from `claude-code` editor attribution across 852 users.
- Separated 168,039 DeepSeek heartbeats from `opencode-cli` editor attribution across 366 users.
- Separated 167,393 GPT heartbeats from `codex-cli` editor attribution across 365 users.
- Corrected 156,840 GitHub Copilot prefix heartbeats across 2,462 users that would otherwise store `github-copilot` as a model.

## Testing

- `docker compose exec -T web bin/rails test`: 465 tests and 2,029 assertions passed.
- `docker compose exec -T web bin/rails test:system`: 42 tests and 218 assertions passed.
- `docker compose exec -T web bundle exec rubocop`: 499 files inspected with no offenses.
- `docker compose exec -T web bin/rails zeitwerk:check`: passed.

## Screenshots / Media

Not applicable.

