### PR TITLE
Prepare development environment for Amp orbs

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -23,4 +23,6 @@ if ! grep -Fxq web <<<"$running_services" || ! grep -Fxq db <<<"$running_service
   docker compose up -d --no-build --remove-orphans
 fi
 
+amp orb services ensure
+
 echo "Hackatime services are ready"

--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+  echo "Docker or Docker Compose is missing; run .agents/setup" >&2
+  exit 1
+fi
+
+if ! sudo docker info >/dev/null 2>&1; then
+  sudo service docker start
+fi
+sudo chmod 0666 /var/run/docker.sock
+
+if sudo service postgresql status >/dev/null 2>&1; then
+  sudo service postgresql stop
+fi
+
+running_services="$(docker compose ps --status running --services)"
+if ! grep -Fxq web <<<"$running_services" || ! grep -Fxq db <<<"$running_services"; then
+  docker compose up -d --no-build --remove-orphans
+fi
+
+echo "Hackatime services are ready"

--- a/.agents/setup
+++ b/.agents/setup
@@ -64,9 +64,12 @@ for attempt in {1..30}; do
   sleep 2
 done
 
-echo "==> Preparing development and test databases"
+echo "==> Installing application dependencies"
 docker compose exec -T web git config --global --add safe.directory /app
-docker compose exec -T web bin/rails db:prepare
+docker compose exec -T web bun upgrade
+docker compose exec -T web bin/setup --skip-server
+
+echo "==> Seeding development and preparing test databases"
 docker compose exec -T web bin/rails db:seed
 docker compose exec -T web env RAILS_ENV=test bin/rails db:prepare
 

--- a/.agents/setup
+++ b/.agents/setup
@@ -70,4 +70,7 @@ docker compose exec -T web bin/rails db:prepare
 docker compose exec -T web bin/rails db:seed
 docker compose exec -T web env RAILS_ENV=test bin/rails db:prepare
 
+echo "==> Starting supervised development services"
+amp orb services ensure
+
 echo "==> Orb setup complete"

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+echo "==> Installing Docker Engine and Compose"
+if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y ca-certificates curl gnupg
+  sudo install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor --yes -o /etc/apt/keyrings/docker.gpg
+  sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian ${VERSION_CODENAME} stable" |
+    sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+  sudo apt-get update
+  sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+fi
+
+echo "==> Starting Docker"
+if ! sudo docker info >/dev/null 2>&1; then
+  sudo service docker start
+fi
+# Orbs are single-user sandboxes. This makes Docker available immediately to
+# Amp's existing process; a group change would only affect future logins.
+sudo chmod 0666 /var/run/docker.sock
+
+# The base orb starts PostgreSQL on port 5432, which collides with the
+# repository's Compose-managed database.
+if sudo service postgresql status >/dev/null 2>&1; then
+  echo "==> Stopping the host PostgreSQL service"
+  sudo service postgresql stop
+fi
+
+echo "==> Creating development environment file"
+if [[ ! -f .env ]]; then
+  cat > .env <<'EOF'
+DATABASE_URL=postgres://postgres:secureorpheus123@db:5432/app_development
+SAILORS_LOG_DATABASE_URL=postgres://postgres:secureorpheus123@db:5432/app_development
+POOL_DATABASE_URL=postgres://postgres:secureorpheus123@db:5432/app_development
+SECRET_KEY_BASE=orb_development_secret_key_base_not_for_production
+ENCRYPTION_PRIMARY_KEY=orb_development_primary_encryption_key
+ENCRYPTION_DETERMINISTIC_KEY=orb_development_deterministic_encryption_key
+ENCRYPTION_KEY_DERIVATION_SALT=orb_development_derivation_salt
+EOF
+fi
+
+echo "==> Building and starting development containers"
+docker compose up -d --build --remove-orphans
+
+echo "==> Waiting for PostgreSQL"
+for attempt in {1..30}; do
+  if docker compose exec -T db pg_isready -U postgres -d app_development >/dev/null 2>&1; then
+    break
+  fi
+  if [[ "$attempt" == 30 ]]; then
+    echo "PostgreSQL did not become ready in time" >&2
+    docker compose ps >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+echo "==> Preparing development and test databases"
+docker compose exec -T web git config --global --add safe.directory /app
+docker compose exec -T web bin/rails db:prepare
+docker compose exec -T web bin/rails db:seed
+docker compose exec -T web env RAILS_ENV=test bin/rails db:prepare
+
+echo "==> Orb setup complete"

--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -1,0 +1,7 @@
+services:
+  web:
+    command: docker compose exec -T -e RUNNING_INSIDE_CONTAINER=1 -e PORT="$PORT" web bin/dev
+    port: 3000
+    portal:
+      title: Hackatime
+      description: Sign in with the seeded test@example.com account.

--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -1,7 +1,7 @@
 services:
   web:
-    command: docker compose exec -T -e RUNNING_INSIDE_CONTAINER=1 -e PORT="$PORT" web bin/dev
-    port: 3000
+    command: docker compose exec -T -e RUNNING_INSIDE_CONTAINER=1 -e PORT=3000 -e PUBLIC_URL="$PUBLIC_URL" -e VITE_RUBY_SSR_BUILD_ENABLED=false web bin/dev
+    port: 3036
     portal:
       title: Hackatime
       description: Sign in with the seeded test@example.com account.

--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -1,6 +1,6 @@
 services:
   web:
-    command: docker compose exec -T -e RUNNING_INSIDE_CONTAINER=1 -e PORT=3000 -e PUBLIC_URL="$PUBLIC_URL" -e VITE_RUBY_SSR_BUILD_ENABLED=false web bin/dev
+    command: docker compose exec -T -e RUNNING_INSIDE_CONTAINER=1 -e PORT=3000 -e PUBLIC_URL="$PUBLIC_URL" web bin/dev
     port: 3036
     portal:
       title: Hackatime

--- a/.gitignore
+++ b/.gitignore
@@ -71,5 +71,6 @@ public/vite
 
 target.txt
 
-.amp/
+.amp/*
+!.amp/services.yaml
 plans/

--- a/app/javascript/components/Button.svelte
+++ b/app/javascript/components/Button.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { Link } from "@inertiajs/svelte";
-  import { Button as BitsButton } from "bits-ui";
   import type { Snippet } from "svelte";
 
   type ButtonType = "button" | "submit" | "reset";
@@ -67,16 +66,16 @@
 
 {#if href}
   {#if native}
-    <BitsButton.Root {href} class={classes} {...rest}>
+    <a {href} class={classes} {...rest}>
       {@render children?.()}
-    </BitsButton.Root>
+    </a>
   {:else}
     <Link {href} class={classes} {...rest}>
       {@render children?.()}
     </Link>
   {/if}
 {:else}
-  <BitsButton.Root {type} class={classes} {...rest}>
+  <button {type} class={classes} {...rest}>
     {@render children?.()}
-  </BitsButton.Root>
+  </button>
 {/if}

--- a/app/javascript/components/Button.svelte
+++ b/app/javascript/components/Button.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Link } from "@inertiajs/svelte";
+  import { Button as BitsButton } from "bits-ui/button";
   import type { Snippet } from "svelte";
 
   type ButtonType = "button" | "submit" | "reset";
@@ -66,16 +67,16 @@
 
 {#if href}
   {#if native}
-    <a {href} class={classes} {...rest}>
+    <BitsButton.Root {href} class={classes} {...rest}>
       {@render children?.()}
-    </a>
+    </BitsButton.Root>
   {:else}
     <Link {href} class={classes} {...rest}>
       {@render children?.()}
     </Link>
   {/if}
 {:else}
-  <button {type} class={classes} {...rest}>
+  <BitsButton.Root {type} class={classes} {...rest}>
     {@render children?.()}
-  </button>
+  </BitsButton.Root>
 {/if}

--- a/app/javascript/components/ModalInner.svelte
+++ b/app/javascript/components/ModalInner.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Dialog } from "bits-ui";
+  import { Dialog } from "bits-ui/dialog";
   import type { Snippet } from "svelte";
 
   let {

--- a/app/javascript/components/MultiSelectCombobox.svelte
+++ b/app/javascript/components/MultiSelectCombobox.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Popover } from "bits-ui";
+  import { Popover } from "bits-ui/popover";
   import Button from "./Button.svelte";
 
   type Option = {

--- a/app/javascript/components/Select.svelte
+++ b/app/javascript/components/Select.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Select as BitsSelect } from "bits-ui";
+  import { Select as BitsSelect } from "bits-ui/select";
 
   type SelectItem = {
     value: string;

--- a/app/javascript/entrypoints/inertia.ts
+++ b/app/javascript/entrypoints/inertia.ts
@@ -1,6 +1,5 @@
 import "@fontsource-variable/spline-sans";
 import { createInertiaApp, type ResolvedComponent } from "@inertiajs/svelte";
-import AppLayout from "../layouts/AppLayout.svelte";
 
 const pages = import.meta.glob<ResolvedComponent>("../pages/**/*.svelte");
 
@@ -71,14 +70,16 @@ createInertiaApp({
     color: "var(--color-primary)",
   },
 
-  layout: () => AppLayout,
-
   resolve: async (name) => {
     const loadPage = pages[`../pages/${name}.svelte`];
     if (!loadPage) {
       throw new Error(`Missing Inertia page component: '${name}.svelte'`);
     }
-    return await loadPage();
+    const component = await loadPage();
+    if (component.layout !== undefined) return component;
+
+    const { default: AppLayout } = await import("../layouts/AppLayout.svelte");
+    return { ...component, layout: AppLayout };
   },
 
   defaults: {
@@ -88,4 +89,4 @@ createInertiaApp({
   },
 });
 
-schedulePrefetch();
+if (import.meta.env.PROD) schedulePrefetch();

--- a/app/javascript/pages/Home/SignedIn.svelte
+++ b/app/javascript/pages/Home/SignedIn.svelte
@@ -11,9 +11,7 @@
   import SetupNotice from "./signedIn/SetupNotice.svelte";
   import TodaySentence from "./signedIn/TodaySentence.svelte";
   import TodaySentenceSkeleton from "./signedIn/TodaySentenceSkeleton.svelte";
-  import Dashboard from "./signedIn/Dashboard.svelte";
   import DashboardSkeleton from "./signedIn/DashboardSkeleton.svelte";
-  import ActivityGraph from "./signedIn/ActivityGraph.svelte";
   import ActivityGraphSkeleton from "./signedIn/ActivityGraphSkeleton.svelte";
 
   let {
@@ -34,6 +32,17 @@
       programming_goals_progress: ProgrammingGoalProgress[];
     };
   } = $props();
+
+  let Dashboard = $state<
+    (typeof import("./signedIn/Dashboard.svelte"))["default"] | null
+  >(null);
+
+  $effect(() => {
+    if (!dashboard_stats?.filterable_dashboard_data || Dashboard) return;
+    import("./signedIn/Dashboard.svelte").then((module) => {
+      Dashboard = module.default;
+    });
+  });
 
   function refreshDashboardData(search: string) {
     router.visit(`${window.location.pathname}${search}`, {
@@ -91,13 +100,15 @@
           />
         {/if}
 
-        {#if dashboard_stats?.filterable_dashboard_data}
+        {#if dashboard_stats?.filterable_dashboard_data && Dashboard}
           <Dashboard
             data={dashboard_stats.filterable_dashboard_data}
             programmingGoalsProgress={dashboard_stats?.programming_goals_progress ||
               []}
             onFiltersChange={refreshDashboardData}
           />
+        {:else}
+          <DashboardSkeleton />
         {/if}
 
         <!-- {#if dashboard_stats?.activity_graph}

--- a/app/javascript/pages/Home/signedIn/FilterShell.svelte
+++ b/app/javascript/pages/Home/signedIn/FilterShell.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Popover } from "bits-ui";
+  import { Popover } from "bits-ui/popover";
   import Button from "../../../components/Button.svelte";
   import type { Snippet } from "svelte";
   import { Icon, ChevronDown } from "svelte-hero-icons";

--- a/app/javascript/pages/Home/signedIn/IntervalSelectBody.svelte
+++ b/app/javascript/pages/Home/signedIn/IntervalSelectBody.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { RadioGroup } from "bits-ui";
+  import { RadioGroup } from "bits-ui/radio-group";
   import Button from "../../../components/Button.svelte";
 
   const INTERVALS = [

--- a/app/javascript/pages/Home/signedIn/MultiSelect.svelte
+++ b/app/javascript/pages/Home/signedIn/MultiSelect.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Checkbox } from "bits-ui";
+  import { Checkbox } from "bits-ui/checkbox";
   import FilterShell from "./FilterShell.svelte";
 
   let {

--- a/app/javascript/pages/Setup/Finish.svelte
+++ b/app/javascript/pages/Setup/Finish.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Checkbox } from "bits-ui";
+  import { Checkbox } from "bits-ui/checkbox";
   import { Icon, InformationCircle } from "svelte-hero-icons";
   import { onMount } from "svelte";
   import confetti from "canvas-confetti";

--- a/app/javascript/pages/Users/Settings/Appearance.svelte
+++ b/app/javascript/pages/Users/Settings/Appearance.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Form } from "@inertiajs/svelte";
-  import { RadioGroup } from "bits-ui";
+  import { RadioGroup } from "bits-ui/radio-group";
   import Button from "../../../components/Button.svelte";
   import SectionCard from "./components/SectionCard.svelte";
   import SettingsShell from "./Shell.svelte";

--- a/app/javascript/pages/Users/Settings/Profile.svelte
+++ b/app/javascript/pages/Users/Settings/Profile.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Form } from "@inertiajs/svelte";
-  import { Tooltip } from "bits-ui";
+  import { Tooltip } from "bits-ui/tooltip";
   import { Icon, ArrowPath, Trash } from "svelte-hero-icons";
   import Button from "../../../components/Button.svelte";
   import Select from "../../../components/Select.svelte";

--- a/app/javascript/pages/Users/Settings/components/CheckboxField.svelte
+++ b/app/javascript/pages/Users/Settings/components/CheckboxField.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Checkbox } from "bits-ui";
+  import { Checkbox } from "bits-ui/checkbox";
   import type { Snippet } from "svelte";
 
   let {

--- a/app/javascript/ssr/ssr.ts
+++ b/app/javascript/ssr/ssr.ts
@@ -1,16 +1,18 @@
 import "@fontsource-variable/spline-sans";
 import { createInertiaApp, type ResolvedComponent } from "@inertiajs/svelte";
-import AppLayout from "../layouts/AppLayout.svelte";
 
 const pages = import.meta.glob<ResolvedComponent>("../pages/**/*.svelte");
 
 createInertiaApp({
-  layout: () => AppLayout,
   resolve: async (name) => {
     const loadPage = pages[`../pages/${name}.svelte`];
     if (!loadPage) {
       throw new Error(`Missing Inertia page component: '${name}.svelte'`);
     }
-    return await loadPage();
+    const component = await loadPage();
+    if (component.layout !== undefined) return component;
+
+    const { default: AppLayout } = await import("../layouts/AppLayout.svelte");
+    return { ...component, layout: AppLayout };
   },
 });

--- a/app/javascript/ssr/ssr.ts
+++ b/app/javascript/ssr/ssr.ts
@@ -2,17 +2,15 @@ import "@fontsource-variable/spline-sans";
 import { createInertiaApp, type ResolvedComponent } from "@inertiajs/svelte";
 import AppLayout from "../layouts/AppLayout.svelte";
 
-const pages = import.meta.glob<ResolvedComponent>("../pages/**/*.svelte", {
-  eager: true,
-});
+const pages = import.meta.glob<ResolvedComponent>("../pages/**/*.svelte");
 
 createInertiaApp({
   layout: () => AppLayout,
-  resolve: (name) => {
-    const component = pages[`../pages/${name}.svelte`];
-    if (!component) {
+  resolve: async (name) => {
+    const loadPage = pages[`../pages/${name}.svelte`];
+    if (!loadPage) {
       throw new Error(`Missing Inertia page component: '${name}.svelte'`);
     }
-    return component;
+    return await loadPage();
   },
 });

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "^4.3.0",
         "@tsconfig/svelte": "^5.0.8",
-        "bits-ui": "^2.18.1",
+        "bits-ui": "2.18.1",
         "canvas-confetti": "^1.9.4",
         "d3-shape": "^3.2.0",
         "hcicons-svelte": "0.2.2",
@@ -40,6 +40,7 @@
   },
   "patchedDependencies": {
     "layercake@8.4.3": "patches/layercake@8.4.3.patch",
+    "bits-ui@2.18.1": "patches/bits-ui@2.18.1.patch",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.3.0",
     "@tsconfig/svelte": "^5.0.8",
-    "bits-ui": "^2.18.1",
+    "bits-ui": "2.18.1",
     "canvas-confetti": "^1.9.4",
     "d3-shape": "^3.2.0",
     "hcicons-svelte": "0.2.2",
@@ -42,6 +42,7 @@
     "prettier-plugin-svelte": "^3.5.2"
   },
   "patchedDependencies": {
+    "bits-ui@2.18.1": "patches/bits-ui@2.18.1.patch",
     "layercake@8.4.3": "patches/layercake@8.4.3.patch"
   }
 }

--- a/patches/bits-ui@2.18.1.patch
+++ b/patches/bits-ui@2.18.1.patch
@@ -2,9 +2,14 @@ diff --git a/package.json b/package.json
 index a9a531f..286d417 100644
 --- a/package.json
 +++ b/package.json
-@@ -12,5 +12,35 @@
+@@ -12,5 +12,40 @@
        "svelte": "./dist/index.js",
        "default": "./dist/index.js"
++    },
++    "./button": {
++      "types": "./dist/bits/button/index.d.ts",
++      "svelte": "./dist/bits/button/index.js",
++      "default": "./dist/bits/button/index.js"
 +    },
 +    "./checkbox": {
 +      "types": "./dist/bits/checkbox/index.d.ts",

--- a/patches/bits-ui@2.18.1.patch
+++ b/patches/bits-ui@2.18.1.patch
@@ -1,0 +1,40 @@
+diff --git a/package.json b/package.json
+index a9a531f..286d417 100644
+--- a/package.json
++++ b/package.json
+@@ -12,5 +12,35 @@
+       "svelte": "./dist/index.js",
+       "default": "./dist/index.js"
++    },
++    "./checkbox": {
++      "types": "./dist/bits/checkbox/index.d.ts",
++      "svelte": "./dist/bits/checkbox/index.js",
++      "default": "./dist/bits/checkbox/index.js"
++    },
++    "./dialog": {
++      "types": "./dist/bits/dialog/index.d.ts",
++      "svelte": "./dist/bits/dialog/index.js",
++      "default": "./dist/bits/dialog/index.js"
++    },
++    "./popover": {
++      "types": "./dist/bits/popover/index.d.ts",
++      "svelte": "./dist/bits/popover/index.js",
++      "default": "./dist/bits/popover/index.js"
++    },
++    "./radio-group": {
++      "types": "./dist/bits/radio-group/index.d.ts",
++      "svelte": "./dist/bits/radio-group/index.js",
++      "default": "./dist/bits/radio-group/index.js"
++    },
++    "./select": {
++      "types": "./dist/bits/select/index.d.ts",
++      "svelte": "./dist/bits/select/index.js",
++      "default": "./dist/bits/select/index.js"
++    },
++    "./tooltip": {
++      "types": "./dist/bits/tooltip/index.d.ts",
++      "svelte": "./dist/bits/tooltip/index.js",
++      "default": "./dist/bits/tooltip/index.js"
+     }
+   },
+   "files": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,24 @@ export default defineConfig({
         },
     proxy: portal
       ? {
-          "^/(?!vite-dev(?:/|$))": "http://localhost:3000",
+          "^/(?!vite-dev(?:/|$))": {
+            target: "http://localhost:3000",
+            changeOrigin: false,
+            configure(proxy) {
+              proxy.on("proxyReq", (proxyRequest, request) => {
+                const forwardedHost =
+                  request.headers["x-forwarded-host"] ?? request.headers.host;
+                if (forwardedHost) {
+                  proxyRequest.setHeader("Host", forwardedHost);
+                  proxyRequest.setHeader("X-Forwarded-Host", forwardedHost);
+                }
+                proxyRequest.setHeader(
+                  "X-Forwarded-Proto",
+                  request.headers["x-forwarded-proto"] ?? "https",
+                );
+              });
+            },
+          },
         }
       : undefined,
     watch: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,8 +30,18 @@ export default defineConfig({
     },
   },
   plugins: [
+    {
+      name: "portal-resolved-url",
+      configureServer(server) {
+        if (!publicUrl) return;
+
+        server.httpServer?.on("listening", () => {
+          if (server.resolvedUrls) server.resolvedUrls.local = [publicUrl];
+        });
+      },
+    },
     inertia({
-      ssr: portal ? false : "ssr/ssr.ts",
+      ssr: "ssr/ssr.ts",
     }),
     svelte(),
     tailwindcss(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ const portal = publicUrl ? new URL(publicUrl) : null;
 export default defineConfig({
   server: {
     origin: publicUrl,
-    allowedHosts: portal ? [portal.hostname] : undefined,
+    allowedHosts: portal ? true : undefined,
     hmr: portal
       ? {
           protocol: portal.protocol === "https:" ? "wss" : "ws",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,18 +4,34 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 import RubyPlugin from "vite-plugin-ruby";
 
+const publicUrl = process.env.PUBLIC_URL?.replace(/\/$/, "");
+const portal = publicUrl ? new URL(publicUrl) : null;
+
 export default defineConfig({
   server: {
-    hmr: {
-      host: "localhost",
-    },
+    origin: publicUrl,
+    allowedHosts: portal ? [portal.hostname] : undefined,
+    hmr: portal
+      ? {
+          protocol: portal.protocol === "https:" ? "wss" : "ws",
+          host: portal.hostname,
+          clientPort: portal.protocol === "https:" ? 443 : Number(portal.port),
+        }
+      : {
+          host: "localhost",
+        },
+    proxy: portal
+      ? {
+          "^/(?!vite-dev(?:/|$))": "http://localhost:3000",
+        }
+      : undefined,
     watch: {
       usePolling: false, // uses a sh*tton of CPU
     },
   },
   plugins: [
     inertia({
-      ssr: "ssr/ssr.ts",
+      ssr: portal ? false : "ssr/ssr.ts",
     }),
     svelte(),
     tailwindcss(),


### PR DESCRIPTION
## Summary of the problem

Fresh Amp orbs do not include Docker or the repository's initialized development environment. Without lifecycle scripts, an agent cannot follow Hackatime's required Docker Compose workflow, the base orb's PostgreSQL service conflicts with the Compose database on port 5432, and the running application is not available through Amp's Portal tab. Persistent Compose volumes also need their Ruby and JavaScript dependencies refreshed when setup runs.

The Portal must expose Vite as the browser-facing service rather than Rails directly. Inertia's development SSR normally emits CSS and font URLs using Vite's private `localhost:3036` listener; those assets are inaccessible to a browser opening a Rails portal and cause missing Spline Sans and broken layout styling.

Cold development loads were also dominated by avoidable compilation: SSR eagerly loaded all 96 pages and the authenticated layout, each `bits-ui` primitive import traversed the package's all-components barrel, and the signed-in chart subtree compiled before its deferred data was available. This produced measured cold SSR times of roughly 5.8 seconds for sign-in and 10 seconds for the authenticated dashboard.

## Describe your changes

- Add an idempotent `.agents/setup` that installs and starts Docker, creates a development `.env` without overwriting an existing file, resolves the host PostgreSQL port conflict, and starts the Compose stack.
- Upgrade the Bun runtime to its latest release during setup, then run the repository's `bin/setup --skip-server` to perform `bundle check`/`bundle install`, install JavaScript packages from the frozen lockfile, and prepare the development database inside the persistent Compose volumes.
- Seed development data and prepare the test database.
- Add a fast `.agents/resume` that repairs Docker and Compose services, then ensures and health-checks the supervised Portal service after an orb wakes.
- Add a committed `.amp/services.yaml` that supervises Hackatime's full `bin/dev` stack and exposes Vite on port 3036 through an authenticated Amp Portal.
- In Portal mode, proxy Rails through Vite so application pages, Vite assets, fonts, HMR, and SSR styles share one authenticated origin, explicitly preserving forwarded host and protocol for Rails redirects and generated URLs.
- Override Vite's advertised resolved URL only in Portal mode so Inertia SSR emits portaled CSS/font links rather than private localhost links. SSR remains enabled both locally and through the Portal.
- Lazy-load page components and the default authenticated layout in both client and SSR resolvers while preserving explicit marketing and no-layout page overrides.
- Keep speculative page prefetching in production, where it fetches built chunks, but disable it in development, where it triggered expensive competing compilations.
- Keep the shared button on Bits UI through the narrow `bits-ui/button` entry while retaining the Inertia `Link` path.
- Patch and pin `bits-ui` 2.18.1 to expose narrow package entry points for the six primitives Hackatime uses, avoiding the 4.7 MB all-components barrel while retaining Bits UI interaction/accessibility behavior.
- Defer the chart-heavy dashboard component until its Inertia-deferred data is available and remove a dead chart import.
- Mark both lifecycle scripts executable and keep generated portal manifests ignored.

Verification:
- Ran `.agents/setup` successfully repeatedly and confirmed repeat runs preserved seeded data.
- Confirmed `bun upgrade` reports Bun v1.3.14 as the latest release in the container.
- Confirmed Bundler dependencies are satisfied and `bun install --frozen-lockfile` completes with the package patches applied.
- Ran `.agents/resume` with healthy services in approximately 1.3 seconds, including Portal health verification.
- Stopped both Compose services and confirmed `.agents/resume` restored them.
- Verified Docker Compose from a clean non-interactive login shell.
- Recreated the web container and confirmed Amp restored the supervised service.
- Measured SSR module warmup decreasing from roughly 13–14 seconds to under one second.
- Measured cold Portal SSR decreasing from 5.8 seconds to 0.21 seconds for sign-in and from 10.0 seconds to 0.55 seconds for the authenticated dashboard; authenticated browser TTFB decreased from 5.9 seconds to 0.84 seconds.
- Used Playwright against signed-out, sign-in, and authenticated dashboard pages and confirmed HTTP 200, SSR hydration, loaded Spline Sans, sidebar rendering, date-filter and logout-dialog keyboard interactions, and zero failed requests or console errors.
- Confirmed raw SSR HTML contains rendered page markup and portaled CSS/font links, with no private `localhost:3036` asset URLs.
- Confirmed production client and SSR Vite builds succeed.
- Ran `bun run check` (0 errors; 3 existing Svelte warnings), targeted Prettier checks, `bun install --frozen-lockfile`, and `git diff --check`.

## Screenshots / Media

Not applicable; this changes the Orb development environment and development loading behavior rather than application UI.