### PR TITLE
Render fast dashboard path during SSR

### DIFF
--- a/app/javascript/pages/Home/SignedIn.svelte
+++ b/app/javascript/pages/Home/SignedIn.svelte
@@ -11,6 +11,7 @@
   import SetupNotice from "./signedIn/SetupNotice.svelte";
   import TodaySentence from "./signedIn/TodaySentence.svelte";
   import TodaySentenceSkeleton from "./signedIn/TodaySentenceSkeleton.svelte";
+  import Dashboard from "./signedIn/Dashboard.svelte";
   import DashboardSkeleton from "./signedIn/DashboardSkeleton.svelte";
   import ActivityGraphSkeleton from "./signedIn/ActivityGraphSkeleton.svelte";
 
@@ -32,17 +33,6 @@
       programming_goals_progress: ProgrammingGoalProgress[];
     };
   } = $props();
-
-  let Dashboard = $state<
-    (typeof import("./signedIn/Dashboard.svelte"))["default"] | null
-  >(null);
-
-  $effect(() => {
-    if (!dashboard_stats?.filterable_dashboard_data || Dashboard) return;
-    import("./signedIn/Dashboard.svelte").then((module) => {
-      Dashboard = module.default;
-    });
-  });
 
   function refreshDashboardData(search: string) {
     router.visit(`${window.location.pathname}${search}`, {
@@ -100,15 +90,13 @@
           />
         {/if}
 
-        {#if dashboard_stats?.filterable_dashboard_data && Dashboard}
+        {#if dashboard_stats?.filterable_dashboard_data}
           <Dashboard
             data={dashboard_stats.filterable_dashboard_data}
             programmingGoalsProgress={dashboard_stats?.programming_goals_progress ||
               []}
             onFiltersChange={refreshDashboardData}
           />
-        {:else}
-          <DashboardSkeleton />
         {/if}
 
         <!-- {#if dashboard_stats?.activity_graph}


### PR DESCRIPTION
## Summary of the problem

The dashboard component was loaded from a client-only `$effect`. Since effects do not run during SSR, signed-in requests always rendered a dashboard skeleton even when Rails supplied `dashboard_stats` immediately from rollups. Hydration then replaced that skeleton with the real dashboard, causing a visible layout shift. A failed dynamic import could also leave the skeleton visible indefinitely.

## Describe your changes

Statically import `Dashboard.svelte` again and let Inertia's `Deferred` component be the single owner of the loading state:

- eager rollup responses now include the real dashboard in SSR HTML and make no deferred request
- genuinely deferred responses still SSR the existing skeleton, request `dashboard_stats`, and then render the dashboard
- remove the redundant client-only component loading state

Validated with:

- Playwright against the Amp Portal, with and without JavaScript, for both eager rollup and deferred interval URLs
- `docker compose exec -T web bun run check`
- `docker compose exec -T web bun x prettier --check app/javascript/pages/Home/SignedIn.svelte`
- `docker compose exec -T web bin/rails test test/controllers/static_pages_controller_test.rb`
- `docker compose exec -T web bin/vite build --ssr --force`

## Screenshots / Media

N/A — this restores the existing dashboard rather than changing its design. Playwright confirmed the eager SSR response contains `Total Time` with zero skeletons, while the deferred response retains the intended skeleton until its partial request completes.
